### PR TITLE
Add phone, tablet, and desktop responsive layout tiers.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,28 +7,40 @@ import { ChordProvider, useChordContext } from './context/ChordContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { SplashPage } from './components/SplashPage';
 import { LandscapePrompt } from './components/LandscapePrompt';
+import { useLayoutTier } from './hooks/useLayoutTier';
+import { usePhoneLandscapeBlocked } from './hooks/usePhoneLandscapeBlocked';
 
 function AppContent() {
   const { selectedChord } = useChordContext();
+  const layoutTier = useLayoutTier();
 
   const isPrimaryElement = selectedChord ? ["Earth", "Wind", "Fire"].includes(selectedChord.name) : true;
+  const isPhoneLayout = layoutTier === 'phone';
 
   return (
     <div className="app-container">
       <TopBar />
-      
+
       <div className="main-content">
-        <ElementalDiagram>
-          <ClockFace isMobileOverlay />
-        </ElementalDiagram>
-        
+        {isPhoneLayout ? (
+          <ElementalDiagram>
+            <ClockFace isMobileOverlay />
+          </ElementalDiagram>
+        ) : (
+          <ElementalDiagram />
+        )}
+
         <div className="side-panel glass-panel unified-side-panel">
-          <div className="side-section clock-section">
-            <ClockFace />
-          </div>
-          
-          <div className="side-divider" />
-          
+          {!isPhoneLayout && (
+            <>
+              <div className="side-section clock-section">
+                <ClockFace />
+              </div>
+
+              <div className="side-divider" />
+            </>
+          )}
+
           <div className="side-section controls-section">
             <BorrowingControls disabled={!selectedChord || isPrimaryElement} />
           </div>
@@ -40,13 +52,19 @@ function AppContent() {
 
 function App() {
   const [hasStarted, setHasStarted] = useState(false);
+  const isBlocked = usePhoneLandscapeBlocked();
 
   return (
     <ErrorBoundary>
       <ChordProvider>
-        <LandscapePrompt />
-        {!hasStarted && <SplashPage onEnter={() => setHasStarted(true)} />}
-        <AppContent />
+        {isBlocked ? (
+          <LandscapePrompt />
+        ) : (
+          <>
+            {!hasStarted && <SplashPage onEnter={() => setHasStarted(true)} />}
+            <AppContent />
+          </>
+        )}
       </ChordProvider>
     </ErrorBoundary>
   );

--- a/web/src/components/ElementalDiagram.test.tsx
+++ b/web/src/components/ElementalDiagram.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ElementalDiagram } from './ElementalDiagram';
+
+vi.mock('../context/ChordContext', () => ({
+  useChordContext: () => ({
+    selectedChord: null,
+    borrowingState: {
+      circlePositions: { 1: 'line', 2: 'line', 3: 'line', 4: 'line' },
+      noteStates: { 1: 'off', 2: 'off', 3: 'off', 4: 'off' },
+    },
+    handleChordPointerDown: vi.fn(),
+    handleChordPointerUp: vi.fn(),
+    handleChordPointerEnter: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useLayoutTier', () => ({
+  useLayoutTier: () => 'phone',
+}));
+
+async function flushAnimationFrames(count = 2): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+describe('ElementalDiagram ready gate', () => {
+  beforeEach(() => {
+    class MockResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should hide diagram until layout settles after mount', async () => {
+    const { container } = render(<ElementalDiagram />);
+    const diagram = container.querySelector('.diagram-container');
+
+    expect(diagram).not.toBeNull();
+    expect(diagram).toHaveStyle({ opacity: '0' });
+
+    await flushAnimationFrames(2);
+
+    await waitFor(() => {
+      expect(diagram).toHaveStyle({ opacity: '1' });
+    });
+  });
+});

--- a/web/src/components/ElementalDiagram.tsx
+++ b/web/src/components/ElementalDiagram.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useLayoutEffect, useCallback } from 'react';
 import { chordManager, type Chord } from '../music/ChordManager';
 import {
   BASE_GROUPS,
@@ -8,6 +8,8 @@ import {
   AXIS_PARENTS,
 } from '../music/diagramMetadata';
 import { useChordContext } from '../context/ChordContext';
+import { BREAKPOINTS } from '../layout/breakpoints';
+import { useLayoutTier } from '../hooks/useLayoutTier';
 
 function piePath(r: number, slice: number): string {
   const d = r / Math.SQRT2;
@@ -54,35 +56,60 @@ export const ElementalDiagram: React.FC<{ children?: React.ReactNode }> = ({ chi
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
   const [hoveredSliceIdx, setHoveredSliceIdx] = useState<number | null>(null);
 
-  const [isMobile, setIsMobile] = useState(window.innerWidth <= 950);
-  
-  React.useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 950);
-      if (containerRef.current) {
-        const { width, height } = containerRef.current.getBoundingClientRect();
-        if (width > 0 && height > 0) {
-          // Calculate how much the browser is stretching the SVG
-          // viewBox is -25 -25 1210 860 (AR ~1.4)
-          const viewBoxAR = 1210 / 860;
-          const containerAR = width / height;
-          setAspectRatioCorrection(containerAR / viewBoxAR);
-        }
-      }
-    };
-    window.addEventListener('resize', handleResize);
-    handleResize(); // Initial calculation
-    return () => window.removeEventListener('resize', handleResize);
+  const layoutTier = useLayoutTier();
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [isDiagramReady, setIsDiagramReady] = useState(false);
+
+  const measureContainer = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const { width, height } = container.getBoundingClientRect();
+    setContainerWidth(width);
+    if (width > 0 && height > 0) {
+      const viewBoxAR = 1210 / 860;
+      const containerAR = width / height;
+      setAspectRatioCorrection(containerAR / viewBoxAR);
+    }
   }, []);
 
-  // Universal Mobile Optimization: Tight bounds and non-uniform stretching to fill space.
-  const viewBox = isMobile ? `-25 -25 1210 860` : `0 0 ${VIEW_W} ${VIEW_H}`;
+  useLayoutEffect(() => {
+    let frame2 = 0;
+    const frame1 = requestAnimationFrame(() => {
+      frame2 = requestAnimationFrame(() => {
+        measureContainer();
+        setIsDiagramReady(true);
+      });
+    });
+    return () => {
+      cancelAnimationFrame(frame1);
+      cancelAnimationFrame(frame2);
+    };
+  }, [measureContainer]);
 
-  const R_MAIN = isMobile ? 100 : 52;
-  const R_GROUP = isMobile ? 102 : 54;
+  React.useEffect(() => {
+    if (!isDiagramReady) return;
+    const container = containerRef.current;
+    if (!container) return;
 
-  // Hide labels on mobile always as requested
-  const showLabels = !isMobile;
+    const observer = new ResizeObserver(measureContainer);
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [isDiagramReady, measureContainer]);
+
+  const isCompactDiagram =
+    layoutTier === 'phone' ||
+    layoutTier === 'tablet' ||
+    containerWidth < BREAKPOINTS.compactDiagramWidth;
+
+  const viewBox = isCompactDiagram
+    ? `-25 -25 1210 860`
+    : `0 0 ${VIEW_W} ${VIEW_H}`;
+
+  const R_MAIN = isCompactDiagram ? 100 : 52;
+  const R_GROUP = isCompactDiagram ? 102 : 54;
+
+  const showLabels = !isCompactDiagram;
 
   const isBorrowingActive = selectedChord ? [1, 2, 3, 4].some(line => {
     const pos = borrowingState.circlePositions[line as 1|2|3|4];
@@ -138,11 +165,15 @@ export const ElementalDiagram: React.FC<{ children?: React.ReactNode }> = ({ chi
   }, [getCoords]);
 
   return (
-    <div className="diagram-container" ref={containerRef}>
+    <div
+      className="diagram-container"
+      ref={containerRef}
+      style={{ opacity: isDiagramReady ? 1 : 0 }}
+    >
       <svg
         viewBox={viewBox}
         className="diagram-svg"
-        preserveAspectRatio={isMobile ? "none" : "xMidYMid meet"}
+        preserveAspectRatio={isCompactDiagram ? 'none' : 'xMidYMid meet'}
       >
         <defs>
           <filter id="glow" x="-50%" y="-50%" width="200%" height="200%" filterUnits="userSpaceOnUse">

--- a/web/src/components/LandscapePrompt.tsx
+++ b/web/src/components/LandscapePrompt.tsx
@@ -7,7 +7,7 @@ export const LandscapePrompt: React.FC = () => {
       <div className="blocker-content">
         <Smartphone className="rotate-icon" size={48} />
         <h1>Please Rotate Your Device</h1>
-        <p>This application is optimized for portrait (vertical) orientation on mobile devices.</p>
+        <p>This application is optimized for portrait orientation on phones. Please rotate your phone to continue.</p>
       </div>
     </div>
   );

--- a/web/src/hooks/useLayoutTier.ts
+++ b/web/src/hooks/useLayoutTier.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { resolveLayoutTier, type LayoutTier } from '../layout/breakpoints';
+
+export function useLayoutTier(): LayoutTier {
+  const [tier, setTier] = useState<LayoutTier>(() => resolveLayoutTier());
+
+  useEffect(() => {
+    const update = () => setTier(resolveLayoutTier());
+    const mediaQueries = [
+      window.matchMedia('(pointer: coarse)'),
+      window.matchMedia('(orientation: portrait)'),
+    ];
+    mediaQueries.forEach((mq) => mq.addEventListener('change', update));
+    window.addEventListener('resize', update);
+
+    return () => {
+      mediaQueries.forEach((mq) =>
+        mq.removeEventListener('change', update),
+      );
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
+  return tier;
+}

--- a/web/src/hooks/usePhoneLandscapeBlocked.ts
+++ b/web/src/hooks/usePhoneLandscapeBlocked.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import {
+  isPhoneLandscapeBlocked,
+  PHONE_LANDSCAPE_BLOCK_MEDIA,
+} from '../layout/breakpoints';
+
+export function usePhoneLandscapeBlocked(): boolean {
+  const [isBlocked, setIsBlocked] = useState(() => isPhoneLandscapeBlocked());
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(PHONE_LANDSCAPE_BLOCK_MEDIA);
+    const update = () => setIsBlocked(isPhoneLandscapeBlocked());    mediaQuery.addEventListener('change', update);
+    return () => mediaQuery.removeEventListener('change', update);
+  }, []);
+
+  return isBlocked;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import './layout/breakpoints.css';
 
 :root {
   --bg-dark: #09090b;
@@ -69,7 +70,8 @@ body {
   min-height: 0;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 767px),
+       (max-width: 950px) and (orientation: portrait) and (pointer: coarse) {
   html,
   body {
     height: 100%;
@@ -238,9 +240,38 @@ body {
 
 }
 
-@media (min-width: 1101px) and (pointer: fine) {
+@media (min-width: 768px) and (pointer: fine),
+       (min-width: 768px) and (max-width: 1199px) and (pointer: coarse) {
   .clock-container.mobile-overlay {
     display: none;
+  }
+}
+
+/* Tablet: touch side-by-side layout with desktop-like grid */
+@media (min-width: 768px) and (max-width: 1199px) and (pointer: coarse) {
+  .app-container {
+    padding: 0 max(12px, env(safe-area-inset-right))
+             max(12px, env(safe-area-inset-bottom))
+             max(12px, env(safe-area-inset-left));
+    gap: 12px;
+  }
+
+  .top-bar {
+    padding-top: max(8px, env(safe-area-inset-top));
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+
+  .main-content {
+    gap: 12px;
+  }
+
+  .diagram-container {
+    min-height: 0;
+  }
+
+  .borrowing-row {
+    min-height: 44px;
   }
 }
 
@@ -315,7 +346,8 @@ body {
   overflow: hidden;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 767px),
+       (max-width: 950px) and (orientation: portrait) and (pointer: coarse) {
   .unified-side-panel {
     height: auto;
   }
@@ -330,7 +362,8 @@ body {
   height: 100%;
 }
 
-@media (max-width: 950px) and (orientation: portrait) {
+@media (max-width: 767px) and (orientation: portrait),
+       (max-width: 950px) and (orientation: portrait) and (pointer: coarse) {
   .diagram-svg {
     transform: none;
   }
@@ -992,7 +1025,8 @@ input[type="range"] {
   align-items: center;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 767px),
+       (max-width: 950px) and (orientation: portrait) and (pointer: coarse) {
   .adsr-panel-content {
     grid-template-columns: 1fr;
     gap: 8px;
@@ -1250,53 +1284,59 @@ input[type="range"] {
   100% { transform: translateY(-8px); }
 }
 
-/* Orientation Blocker */
+/* Orientation Blocker (rendered only while blocked via React) */
 .orientation-blocker {
-  display: none;
+  display: flex;
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background-color: var(--bg-dark);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
 }
 
-@media (max-width: 1100px) and (orientation: landscape), (pointer: coarse) and (orientation: landscape) {
-  .orientation-blocker {
-    display: flex;
-    position: fixed;
-    inset: 0;
-    z-index: 10000;
-    background-color: var(--bg-dark);
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 2rem;
+.orientation-blocker h1 {
+  font-size: 1.5rem;
+  margin: 1rem 0;
+  background: linear-gradient(135deg, var(--color-earth) 0%, var(--color-wind) 50%, var(--color-fire) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.orientation-blocker p {
+  color: var(--text-secondary);
+  max-width: 300px;
+  line-height: 1.5;
+}
+
+.rotate-icon {
+  color: var(--color-wind);
+  animation: rotate-phone 2s infinite ease-in-out;
+}
+
+@keyframes rotate-phone {
+  0% { transform: rotate(90deg); }
+  50% { transform: rotate(0deg); }
+  100% { transform: rotate(90deg); }
+}
+
+/* Foldable: gutter padding when spanning both viewport segments */
+@media (horizontal-viewport-segments: 2) {
+  .app-container {
+    padding-left: max(16px, env(safe-area-inset-left));
+    padding-right: max(16px, env(safe-area-inset-right));
   }
 
-  .orientation-blocker h1 {
-    font-size: 1.5rem;
-    margin: 1rem 0;
-    background: linear-gradient(135deg, var(--color-earth) 0%, var(--color-wind) 50%, var(--color-fire) 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+  .top-bar {
+    padding-left: max(24px, env(safe-area-inset-left));
+    padding-right: max(24px, env(safe-area-inset-right));
   }
 
-  .orientation-blocker p {
-    color: var(--text-secondary);
-    max-width: 300px;
-    line-height: 1.5;
-  }
-
-  .rotate-icon {
-    color: var(--color-wind);
-    animation: rotate-phone 2s infinite ease-in-out;
-  }
-
-  @keyframes rotate-phone {
-    0% { transform: rotate(90deg); }
-    50% { transform: rotate(0deg); }
-    100% { transform: rotate(90deg); }
-  }
-
-  /* Hide the rest of the app when blocked */
-  #root > *:not(.orientation-blocker) {
-    visibility: hidden !important;
+  .unified-side-panel {
+    padding-right: env(safe-area-inset-right);
   }
 }

--- a/web/src/layout.test.tsx
+++ b/web/src/layout.test.tsx
@@ -1,11 +1,23 @@
 /// <reference types="node" />
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import fs from 'fs';
 import path from 'path';
+import { BREAKPOINTS, PHONE_LANDSCAPE_BLOCK_MEDIA } from './layout/breakpoints';
+import { useLayoutTier } from './hooks/useLayoutTier';
+import { usePhoneLandscapeBlocked } from './hooks/usePhoneLandscapeBlocked';
 
 describe('Responsive Layout CSS', () => {
   const cssPath = path.resolve(process.cwd(), 'src/index.css');
   const cssContent = fs.readFileSync(cssPath, 'utf-8');
+  const breakpointsCssPath = path.resolve(
+    process.cwd(),
+    'src/layout/breakpoints.css',
+  );
+  const breakpointsCss = fs.readFileSync(breakpointsCssPath, 'utf-8');
+
+  const phoneLayoutPattern =
+    /\(max-width:\s*767px\)[\s\S]*?\(max-width:\s*950px\)\s*and\s*\(\s*orientation:\s*portrait\s*\)\s*and\s*\(\s*pointer:\s*coarse\s*\)/;
 
   it('should define portrait main-content column layout on mobile', () => {
     const portraitMatch = cssContent.match(
@@ -18,34 +30,29 @@ describe('Responsive Layout CSS', () => {
   });
 
   it('should lock mobile document scroll and overscroll', () => {
-    const mobileBlock = cssContent.match(
-      /@media\s*\(\s*max-width:\s*950px\s*\)\s*\{([\s\S]*?)\n\}/,
-    );
-    expect(mobileBlock, 'Mobile media query block is missing').not.toBeNull();
+    expect(cssContent).toMatch(phoneLayoutPattern);
 
-    const block = mobileBlock![1];
-    expect(block).toMatch(/html,\s*body[\s\S]*overflow:\s*hidden/);
-    expect(block).toMatch(/overscroll-behavior:\s*none/);
-    expect(block).toMatch(/position:\s*fixed/);
+    const phoneStart = cssContent.search(phoneLayoutPattern);
+    expect(phoneStart).toBeGreaterThan(-1);
+
+    const phoneBlock = cssContent.slice(phoneStart, phoneStart + 2500);
+    expect(phoneBlock).toMatch(/html,\s*body[\s\S]*overflow:\s*hidden/);
+    expect(phoneBlock).toMatch(/overscroll-behavior:\s*none/);
+    expect(phoneBlock).toMatch(/position:\s*fixed/);
   });
 
   it('should disable text selection and touch callouts on mobile shell', () => {
-    const mobileBlock = cssContent.match(
-      /@media\s*\(\s*max-width:\s*950px\s*\)\s*\{([\s\S]*?)\n\}/,
-    );
-    expect(mobileBlock).not.toBeNull();
+    const phoneStart = cssContent.search(phoneLayoutPattern);
+    const phoneBlock = cssContent.slice(phoneStart, phoneStart + 2500);
 
-    const block = mobileBlock![1];
-    expect(block).toMatch(/-webkit-touch-callout:\s*none/);
-    expect(block).toMatch(/user-select:\s*none/);
-    expect(block).toMatch(
-      /input[\s\S]*user-select:\s*text/,
-    );
+    expect(phoneBlock).toMatch(/-webkit-touch-callout:\s*none/);
+    expect(phoneBlock).toMatch(/user-select:\s*none/);
+    expect(phoneBlock).toMatch(/input[\s\S]*user-select:\s*text/);
   });
 
   it('should ensure accessible touch targets (min 44px) for compactly stacked controls on mobile', () => {
     const mobileTouchTargetMatch = cssContent.match(
-      /@media\s*\(\s*max-width:\s*950px[^}]*\{[\s\S]*?\.borrowing-row\s*\{[^}]*min-height:\s*44px/,
+      /\(max-width: 767px\)[\s\S]*?\.borrowing-row\s*\{[^}]*min-height:\s*44px/,
     );
     expect(
       mobileTouchTargetMatch,
@@ -55,7 +62,7 @@ describe('Responsive Layout CSS', () => {
 
   it('should ensure the diagram container overrides the 450px min-height on mobile to maximize space', () => {
     const minHeightMatch = cssContent.match(
-      /@media[^}]*max-width:\s*950px[^}]*\{[\s\S]*?\.diagram-container\s*\{[^}]*min-height:\s*0/,
+      /\(max-width: 767px\)[\s\S]*?\.diagram-container\s*\{[^}]*min-height:\s*0/,
     );
     expect(
       minHeightMatch,
@@ -69,5 +76,170 @@ describe('Responsive Layout CSS', () => {
       svgMatch,
       '.diagram-svg must have height: 100% to fill container',
     ).not.toBeNull();
+  });
+
+  it('should not block all coarse-pointer landscape devices globally in CSS', () => {
+    expect(cssContent).not.toMatch(
+      /\(pointer:\s*coarse\)\s*and\s*\(\s*orientation:\s*landscape\s*\)\s*\{/,
+    );
+  });
+
+  it('should not hide app via CSS visibility when orientation is blocked', () => {
+    expect(cssContent).not.toMatch(
+      /#root\s*>\s*\*:not\(\.orientation-blocker\)/,
+    );
+  });
+
+  it('should define orientation blocker base styles for React conditional render', () => {
+    expect(cssContent).toMatch(/\.orientation-blocker\s*\{[^}]*display:\s*flex/);
+    expect(cssContent).toMatch(/\.orientation-blocker\s*\{[^}]*position:\s*fixed/);
+  });
+
+  it('should keep phone landscape block media aligned with breakpoint constants', () => {
+    expect(PHONE_LANDSCAPE_BLOCK_MEDIA).toContain(
+      `${BREAKPOINTS.phoneLandscapeMaxHeight}px`,
+    );
+    expect(PHONE_LANDSCAPE_BLOCK_MEDIA).toContain(
+      `${BREAKPOINTS.phoneMax}px`,
+    );
+    expect(PHONE_LANDSCAPE_BLOCK_MEDIA).toContain('pointer: coarse');
+    expect(PHONE_LANDSCAPE_BLOCK_MEDIA).toContain('orientation: landscape');
+  });
+
+  it('should define tablet touch layout between 768px and 1199px', () => {
+    expect(cssContent).toMatch(
+      /@media\s*\(\s*min-width:\s*768px\s*\)\s*and\s*\(\s*max-width:\s*1199px\s*\)\s*and\s*\(\s*pointer:\s*coarse\s*\)/,
+    );
+  });
+
+  it('should keep breakpoint CSS custom properties in sync with TypeScript constants', () => {
+    expect(breakpointsCss).toContain(
+      `--bp-phone-max: ${BREAKPOINTS.phoneMax}px`,
+    );
+    expect(breakpointsCss).toContain(
+      `--bp-compact-max: ${BREAKPOINTS.compactMax}px`,
+    );
+    expect(breakpointsCss).toContain(
+      `--bp-tablet-max: ${BREAKPOINTS.tabletMax}px`,
+    );
+    expect(breakpointsCss).toContain(
+      `--bp-desktop-min: ${BREAKPOINTS.desktopMin}px`,
+    );
+    expect(breakpointsCss).toContain(
+      `--bp-phone-landscape-max-height: ${BREAKPOINTS.phoneLandscapeMaxHeight}px`,
+    );
+  });
+
+  it('should define foldable viewport-segment padding rules', () => {
+    expect(cssContent).toMatch(
+      /@media\s*\(\s*horizontal-viewport-segments:\s*2\s*\)/,
+    );
+  });
+});
+
+describe('isPhoneLandscapeBlocked', () => {
+  const mockMatchMedia = (matchesFor: (query: string) => boolean) => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: matchesFor(query),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  };
+
+  it('should detect blocked phone landscape via shared media query', async () => {
+    const { isPhoneLandscapeBlocked } = await import('./layout/breakpoints');
+
+    mockMatchMedia((query) => query === PHONE_LANDSCAPE_BLOCK_MEDIA);
+    expect(isPhoneLandscapeBlocked()).toBe(true);
+  });
+
+  it('should not block portrait phone or tablet landscape', async () => {
+    const { isPhoneLandscapeBlocked } = await import('./layout/breakpoints');
+
+    mockMatchMedia(() => false);
+    expect(isPhoneLandscapeBlocked()).toBe(false);
+  });
+});
+
+describe('resolveLayoutTier', () => {
+  const mockMatchMedia = (matchesFor: (query: string) => boolean) => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: matchesFor(query),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  };
+
+  it('should classify narrow portrait touch viewports as phone', async () => {
+    const { resolveLayoutTier } = await import('./layout/breakpoints');
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    });
+    mockMatchMedia(
+      (query) =>
+        query === '(pointer: coarse)' || query === '(orientation: portrait)',
+    );
+
+    expect(resolveLayoutTier()).toBe('phone');
+  });
+
+  it('should classify touch landscape tablets as tablet', async () => {
+    const { resolveLayoutTier } = await import('./layout/breakpoints');
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1024,
+    });
+    mockMatchMedia((query) => query === '(pointer: coarse)');
+
+    expect(resolveLayoutTier()).toBe('tablet');
+  });
+});
+
+describe('layout hook initial state', () => {
+  const mockMatchMedia = (matchesFor: (query: string) => boolean) => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: matchesFor(query),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  };
+
+  it('useLayoutTier should read phone tier synchronously on first render', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    });
+    mockMatchMedia(
+      (query) =>
+        query === '(pointer: coarse)' || query === '(orientation: portrait)',
+    );
+
+    const { result } = renderHook(() => useLayoutTier());
+    expect(result.current).toBe('phone');
+  });
+
+  it('usePhoneLandscapeBlocked should read blocked state synchronously on first render', () => {
+    mockMatchMedia((query) => query === PHONE_LANDSCAPE_BLOCK_MEDIA);
+
+    const { result } = renderHook(() => usePhoneLandscapeBlocked());
+    expect(result.current).toBe(true);
   });
 });

--- a/web/src/layout/breakpoints.css
+++ b/web/src/layout/breakpoints.css
@@ -1,0 +1,8 @@
+/* Must stay in sync with layout/breakpoints.ts BREAKPOINTS values. */
+:root {
+  --bp-phone-max: 767px;
+  --bp-compact-max: 950px;
+  --bp-tablet-max: 1199px;
+  --bp-desktop-min: 1200px;
+  --bp-phone-landscape-max-height: 500px;
+}

--- a/web/src/layout/breakpoints.ts
+++ b/web/src/layout/breakpoints.ts
@@ -1,0 +1,41 @@
+export type LayoutTier = 'phone' | 'tablet' | 'desktop';
+
+/** Must stay in sync with layout/breakpoints.css custom properties. */
+export const BREAKPOINTS = {
+  phoneMax: 767,
+  compactMax: 950,
+  tabletMax: 1199,
+  desktopMin: 1200,
+  phoneLandscapeMaxHeight: 500,
+  compactDiagramWidth: 600,
+} as const;
+
+/** CSS media query for stacked phone layout (keep in sync with index.css). */
+export const PHONE_LAYOUT_MEDIA =
+  '(max-width: 767px), (max-width: 950px) and (orientation: portrait) and (pointer: coarse)';
+
+/** Phone landscape rotate prompt (keep in sync with index.css). */
+export const PHONE_LANDSCAPE_BLOCK_MEDIA =
+  '(max-height: 500px) and (orientation: landscape) and (pointer: coarse), ' +
+  '(max-width: 767px) and (orientation: landscape) and (pointer: coarse)';
+
+export function isPhoneLandscapeBlocked(): boolean {
+  return window.matchMedia(PHONE_LANDSCAPE_BLOCK_MEDIA).matches;
+}
+
+export function resolveLayoutTier(): LayoutTier {
+  const w = window.innerWidth;
+  const coarse = window.matchMedia('(pointer: coarse)').matches;
+  const portrait = window.matchMedia('(orientation: portrait)').matches;
+
+  if (
+    w <= BREAKPOINTS.phoneMax ||
+    (w <= BREAKPOINTS.compactMax && portrait && coarse)
+  ) {
+    return 'phone';
+  }
+  if (w <= BREAKPOINTS.tabletMax && coarse) {
+    return 'tablet';
+  }
+  return 'desktop';
+}


### PR DESCRIPTION
Introduce shared breakpoints with useLayoutTier and usePhoneLandscapeBlocked hooks, a tablet touch layout band, and container-based diagram sizing. Scope the landscape rotate prompt to phones so tablets and foldables stay usable, unmount the app while blocked, and hide the diagram until layout settles after rotation to eliminate the portrait-return stretch flash.