### PR TITLE
Elemental contrary-motion voicing, Position rename, and voice borrowing mute fix

### DIFF
--- a/web/src/components/BorrowingControls.tsx
+++ b/web/src/components/BorrowingControls.tsx
@@ -259,6 +259,7 @@ export const BorrowingControls: React.FC<BorrowingControlsProps> = ({ disabled }
                 className="voice-label-container"
                 onClick={() => handleToggleMute(line)}
                 style={{ cursor: disabled ? 'default' : 'pointer' }}
+                title="Mute removes this pitch class from the entire voicing (all octaves)"
               >
                 <div className={`power-led ${muted ? 'off' : 'on'}`} />
                 <div className="note-label">{getVoiceLabel(line)}</div>

--- a/web/src/components/ClockFace.test.tsx
+++ b/web/src/components/ClockFace.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ClockFace } from './ClockFace';
+
+vi.mock('../context/ChordContext', () => ({
+  useChordContext: () => ({
+    tonalCenter: 10,
+    activePitches: [58, 62, 65, 69],
+    selectedChord: { name: 'Branch', traditionalName: 'Bb maj6' },
+  }),
+}));
+
+describe('ClockFace playing notes readout', () => {
+  it('shows inline traditional name and notes on desktop', () => {
+    const { container } = render(<ClockFace />);
+    expect(screen.getByText('Bb maj6 - Bb3 D4 F4 A4')).toBeInTheDocument();
+    expect(container.querySelector('.playing-notes')).toBeNull();
+  });
+
+  it('shows playing notes on a separate row on mobile overlay', () => {
+    const { container } = render(<ClockFace isMobileOverlay />);
+    const clockInfo = container.querySelector('.clock-info');
+    expect(clockInfo?.querySelector('.traditional-name')?.textContent).toBe(
+      'Bb maj6'
+    );
+    expect(clockInfo?.querySelector('.playing-notes')?.textContent).toBe(
+      'Bb3 D4 F4 A4'
+    );
+  });
+});

--- a/web/src/components/ClockFace.tsx
+++ b/web/src/components/ClockFace.tsx
@@ -3,8 +3,14 @@ import { NOTE_NAMES_FLAT } from '../music/config';
 import {
   CHORD_OVERLAY_MAX_CHEM_COUNT,
   CHORD_OVERLAY_MAX_NAME,
+  CHORD_OVERLAY_MAX_PLAYING_NOTES,
   mobileChordDisplayName,
 } from '../music/diagramMetadata';
+import {
+  formatChordReadout,
+  formatPlayingNotes,
+} from '../music/formatPlayingNotes';
+import { computeElementFormula } from '../music/elementChemistry';
 import { useChordContext } from '../context/ChordContext';
 import { DiagramOverlayPill } from './DiagramOverlayPill';
 
@@ -26,6 +32,8 @@ const CHORD_PILL_SIZER = (
         Fire<sub>{CHORD_OVERLAY_MAX_CHEM_COUNT}</sub>
       </span>
     </div>
+    <span className="traditional-name">Bb maj6</span>
+    <span className="playing-notes">{CHORD_OVERLAY_MAX_PLAYING_NOTES}</span>
   </>
 );
 
@@ -73,22 +81,15 @@ export const ClockFace: React.FC<{ isMobileOverlay?: boolean }> = ({
     return mobileChordDisplayName(elementalName);
   }, [elementalName, isMobileOverlay]);
 
-  const elementFormula = React.useMemo(() => {
-    const active = activePitches.filter((p): p is number => p !== null);
-    if (active.length === 0) return null;
+  const playingNotes = React.useMemo(
+    () => formatPlayingNotes(activePitches),
+    [activePitches]
+  );
 
-    let earth = 0;
-    let wind = 0;
-    let fire = 0;
-    for (const p of active) {
-      const relPc = ((p % 12) - tonalCenter + 12) % 12;
-      const rem = relPc % 3;
-      if (rem === 0) earth++;
-      else if (rem === 1) wind++;
-      else fire++;
-    }
-    return { earth, wind, fire };
-  }, [activePitches, tonalCenter]);
+  const elementFormula = React.useMemo(
+    () => computeElementFormula(activePitches, tonalCenter),
+    [activePitches, tonalCenter]
+  );
 
   const getElementColor = (relativePitchClass: number) => {
     const rem = ((relativePitchClass % 3) + 3) % 3;
@@ -161,7 +162,14 @@ export const ClockFace: React.FC<{ isMobileOverlay?: boolean }> = ({
           )}
         </div>
       )}
-      <div className="traditional-name">{traditionalName || '---'}</div>
+      <div className="traditional-name">
+        {isMobileOverlay
+          ? traditionalName || '---'
+          : formatChordReadout(traditionalName, activePitches)}
+      </div>
+      {isMobileOverlay && playingNotes && (
+        <div className="playing-notes">{playingNotes}</div>
+      )}
     </>
   );
 

--- a/web/src/components/DiagramVoicingOverlay.tsx
+++ b/web/src/components/DiagramVoicingOverlay.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
-  tiltInversionLevelName,
+  tiltPositionLevelName,
   tiltVoicingOverlayLabel,
-  TILT_INVERSION_LEVEL_NAMES,
+  TILT_POSITION_MOBILE_LABELS,
   TILT_VOICING_OVERLAY_LABELS,
   TILT_VOICING_OVERLAY_MAX_LABEL,
   TILT_VOICING_LEVEL_NAMES,
@@ -10,11 +10,11 @@ import {
 import { useChordContext } from '../context/ChordContext';
 import { DiagramOverlayPill } from './DiagramOverlayPill';
 
-/** Shared sizer so voicing and inversion pills stay the same width. */
+/** Shared sizer so voicing and position pills stay the same width. */
 const TOP_PILL_SIZER = TILT_VOICING_OVERLAY_MAX_LABEL;
 
 /**
- * Phone-only overlay: voicing (top left) and inversion (top right), mirroring
+ * Phone-only overlay: voicing (top left) and position (top right), mirroring
  * the clock/chord info anchored to the diagram bottom corners.
  */
 export const DiagramVoicingOverlay: React.FC = () => {
@@ -22,8 +22,8 @@ export const DiagramVoicingOverlay: React.FC = () => {
     playStyle,
     staticVoicingLevel,
     setStaticVoicingLevel,
-    staticInversionLevel,
-    setStaticInversionLevel,
+    staticPositionLevel,
+    setStaticPositionLevel,
     tiltStatus,
     tiltSample,
     requestTiltPermission,
@@ -94,17 +94,17 @@ export const DiagramVoicingOverlay: React.FC = () => {
     );
   };
 
-  const renderInversionValue = () => {
+  const renderPositionValue = () => {
     if (!isTilt) {
       return (
         <select
           className="diagram-overlay-select"
-          value={staticInversionLevel}
-          onChange={(e) => setStaticInversionLevel(Number(e.target.value))}
-          title="Inversion"
-          aria-label="Inversion"
+          value={staticPositionLevel}
+          onChange={(e) => setStaticPositionLevel(Number(e.target.value))}
+          title="Position"
+          aria-label="Position"
         >
-          {TILT_INVERSION_LEVEL_NAMES.map((name, idx) => (
+          {TILT_POSITION_MOBILE_LABELS.map((name, idx) => (
             <option key={name} value={idx}>{name}</option>
           ))}
         </select>
@@ -114,9 +114,9 @@ export const DiagramVoicingOverlay: React.FC = () => {
     return (
       <span
         className="diagram-overlay-readout"
-        title="Pitch selects inversion"
+        title="Pitch selects position"
       >
-        {tiltInversionLevelName(tiltSample)}
+        {tiltPositionLevelName(tiltSample, 'mobile')}
       </span>
     );
   };
@@ -131,11 +131,11 @@ export const DiagramVoicingOverlay: React.FC = () => {
         {renderVoicingValue()}
       </DiagramOverlayPill>
       <DiagramOverlayPill
-        label="Inversion"
+        label="Position"
         corner="top-right"
         sizerText={TOP_PILL_SIZER}
       >
-        {renderInversionValue()}
+        {renderPositionValue()}
       </DiagramOverlayPill>
     </div>
   );

--- a/web/src/components/ElementalDiagram.tsx
+++ b/web/src/components/ElementalDiagram.tsx
@@ -51,6 +51,7 @@ export const ElementalDiagram: React.FC<{ children?: React.ReactNode }> = ({ chi
   const [aspectRatioCorrection, setAspectRatioCorrection] = useState(1);
 
   const {
+    tonalCenter,
     selectedChord,
     borrowingState,
     handleChordPointerDown,
@@ -173,7 +174,11 @@ export const ElementalDiagram: React.FC<{ children?: React.ReactNode }> = ({ chi
     };
 
     return { earth, wind, fire, earthC, windC, fireC, groupCenters, getParentCoords, getGroupParentCoords };
-  }, [getCoords]);
+  }, [getCoords, tonalCenter]);
+
+  const resolveFreshChord = useCallback((chord: Chord) => {
+    return chordManager.getChordByName(chord.name) ?? chord;
+  }, []);
 
   return (
     <div
@@ -382,11 +387,11 @@ export const ElementalDiagram: React.FC<{ children?: React.ReactNode }> = ({ chi
               onPointerDown={(e) => {
                 e.preventDefault();
                 e.currentTarget.releasePointerCapture(e.pointerId);
-                handleChordPointerDown(chord);
+                handleChordPointerDown(resolveFreshChord(chord));
               }}
               onPointerUp={() => handleChordPointerUp()}
               onPointerEnter={() => {
-                handleChordPointerEnter(chord);
+                handleChordPointerEnter(resolveFreshChord(chord));
               }}
               style={{ cursor: 'pointer' }}
             >

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -3,10 +3,10 @@ import { SlidersHorizontal, Square } from 'lucide-react';
 import { NOTE_NAMES_FLAT } from '../music/config';
 import {
   tiltVoicingLevelName,
-  tiltInversionLevelName,
+  tiltPositionLevelName,
   TILT_READOUT_MAX_LABEL,
-  TILT_INVERSION_MAX_LABEL,
-  TILT_INVERSION_DESKTOP_LABELS,
+  TILT_POSITION_MAX_LABEL,
+  TILT_POSITION_DESKTOP_LABELS,
   TILT_VOICING_LEVEL_NAMES,
   TILT_VOICING_OVERLAY_LABELS,
 } from '../music/TiltVoicingEngine';
@@ -18,7 +18,7 @@ export const TopBar: React.FC = () => {
   const {
     tonalCenter, setTonalCenter,
     staticVoicingLevel, setStaticVoicingLevel,
-    staticInversionLevel, setStaticInversionLevel,
+    staticPositionLevel, setStaticPositionLevel,
     octaveRange, setOctaveRange,
     chorusWet, setChorusWet,
     delayWet, setDelayWet,
@@ -157,7 +157,7 @@ export const TopBar: React.FC = () => {
                     {tiltStatus === 'active' && (
                       <span
                         className="tilt-readout"
-                        title="Live tilt: roll sets voicing width, pitch selects inversion"
+                        title="Live tilt: roll sets voicing width, pitch selects position"
                       >
                         {tiltVoicingLevelName(tiltSample)}
                       </span>
@@ -169,13 +169,13 @@ export const TopBar: React.FC = () => {
                       className="voicing-readout-slot__sizer"
                       aria-hidden="true"
                     >
-                      {TILT_INVERSION_MAX_LABEL}
+                      {TILT_POSITION_MAX_LABEL}
                     </span>
                     <span
                       className="tilt-readout"
-                      title="Pitch tilt selects parallel inversion"
+                      title="Pitch tilt selects parallel position"
                     >
-                      {tiltInversionLevelName(tiltSample)}
+                      {tiltPositionLevelName(tiltSample, 'desktop')}
                     </span>
                   </div>
                 </>
@@ -196,13 +196,13 @@ export const TopBar: React.FC = () => {
                   </select>
 
                   <select
-                    value={staticInversionLevel}
+                    value={staticPositionLevel}
                     onChange={(e) =>
-                      setStaticInversionLevel(Number(e.target.value))
+                      setStaticPositionLevel(Number(e.target.value))
                     }
-                    title="Inversion"
+                    title="Position"
                   >
-                    {TILT_INVERSION_DESKTOP_LABELS.map((name, idx) => (
+                    {TILT_POSITION_DESKTOP_LABELS.map((name, idx) => (
                       <option key={name} value={idx}>{name}</option>
                     ))}
                   </select>

--- a/web/src/context/ChordContext.tsx
+++ b/web/src/context/ChordContext.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_OCTAVE_RANGE,
 } from '../music/config';
 import {
-  DEFAULT_STATIC_INVERSION_LEVEL,
+  DEFAULT_STATIC_POSITION_LEVEL,
   DEFAULT_STATIC_VOICING_LEVEL,
   type TiltSample,
 } from '../music/TiltVoicingEngine';
@@ -33,8 +33,8 @@ interface ChordContextType {
   setTonalCenter: (val: number) => void;
   staticVoicingLevel: number;
   setStaticVoicingLevel: (val: number) => void;
-  staticInversionLevel: number;
-  setStaticInversionLevel: (val: number) => void;
+  staticPositionLevel: number;
+  setStaticPositionLevel: (val: number) => void;
   octaveRange: number;
   setOctaveRange: (val: number) => void;
   selectedChord: Chord | null;
@@ -97,8 +97,8 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
   const [staticVoicingLevel, setStaticVoicingLevel] = useState(
     DEFAULT_STATIC_VOICING_LEVEL
   );
-  const [staticInversionLevel, setStaticInversionLevel] = useState(
-    DEFAULT_STATIC_INVERSION_LEVEL
+  const [staticPositionLevel, setStaticPositionLevel] = useState(
+    DEFAULT_STATIC_POSITION_LEVEL
   );
   const [octaveRange, setOctaveRange] = useState(DEFAULT_OCTAVE_RANGE);
   const [selectedChord, setSelectedChord] = useState<Chord | null>(null);
@@ -131,14 +131,14 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
   const deviceTilt = useDeviceTilt(handleTiltLevelChange);
 
   const staticVoicingLevelRef = useRef(staticVoicingLevel);
-  const staticInversionLevelRef = useRef(staticInversionLevel);
+  const staticPositionLevelRef = useRef(staticPositionLevel);
   const tonalCenterRef = useRef(tonalCenter);
   useEffect(() => {
     staticVoicingLevelRef.current = staticVoicingLevel;
   }, [staticVoicingLevel]);
   useEffect(() => {
-    staticInversionLevelRef.current = staticInversionLevel;
-  }, [staticInversionLevel]);
+    staticPositionLevelRef.current = staticPositionLevel;
+  }, [staticPositionLevel]);
   useEffect(() => {
     tonalCenterRef.current = tonalCenter;
   }, [tonalCenter]);
@@ -150,7 +150,7 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
     setSelectedChord,
     tiltRef: deviceTilt.tiltRef,
     staticVoicingLevelRef,
-    staticInversionLevelRef,
+    staticPositionLevelRef,
     tonalCenterRef,
   });
 
@@ -212,7 +212,7 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
     tonalCenter,
     octaveRange,
     staticVoicingLevel,
-    staticInversionLevel,
+    staticPositionLevel,
     getBorrowingStateForChord,
     borrowingStateRef,
     setBorrowingState,
@@ -224,8 +224,8 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
     setTonalCenter,
     staticVoicingLevel,
     setStaticVoicingLevel,
-    staticInversionLevel,
-    setStaticInversionLevel,
+    staticPositionLevel,
+    setStaticPositionLevel,
     octaveRange,
     setOctaveRange,
     selectedChord,

--- a/web/src/context/ChordContext.tsx
+++ b/web/src/context/ChordContext.tsx
@@ -132,12 +132,16 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
 
   const staticVoicingLevelRef = useRef(staticVoicingLevel);
   const staticInversionLevelRef = useRef(staticInversionLevel);
+  const tonalCenterRef = useRef(tonalCenter);
   useEffect(() => {
     staticVoicingLevelRef.current = staticVoicingLevel;
   }, [staticVoicingLevel]);
   useEffect(() => {
     staticInversionLevelRef.current = staticInversionLevel;
   }, [staticInversionLevel]);
+  useEffect(() => {
+    tonalCenterRef.current = tonalCenter;
+  }, [tonalCenter]);
 
   const playback = useChordPlayback({
     getBorrowingStateForChord: borrowing.getBorrowingStateForChord,
@@ -147,6 +151,7 @@ export const ChordProvider: React.FC<ChordProviderProps> = ({ children }) => {
     tiltRef: deviceTilt.tiltRef,
     staticVoicingLevelRef,
     staticInversionLevelRef,
+    tonalCenterRef,
   });
 
   useEffect(() => {

--- a/web/src/hooks/useChordPlayback.ts
+++ b/web/src/hooks/useChordPlayback.ts
@@ -54,10 +54,18 @@ export function useChordPlayback({
 
   const computeVoicedPitches = useCallback(
     (chord: Chord, state: BorrowingState, tilt: TiltSample): number[] => {
-      const structure = borrowingLogic.generatePitchStructure(chord, state);
+      const structure = borrowingLogic.generatePitchStructureForVoicing(
+        chord,
+        state
+      );
       const tonalCenter = tonalCenterRef.current;
       const octaveRange = chordManager.getOctaveRange();
+      const mutedPitchClasses = borrowingLogic.getMutedPitchClasses(
+        chord,
+        state
+      );
 
+      let voiced: number[];
       if (isElementalName(chord.name)) {
         const resolved = resolveElementalPlayback(
           chord,
@@ -65,7 +73,7 @@ export function useChordPlayback({
           octaveRange,
           previousChordRef.current
         );
-        return computeTiltVoicing(
+        voiced = computeTiltVoicing(
           structure,
           resolved.rootPitchClass,
           tilt,
@@ -73,16 +81,18 @@ export function useChordPlayback({
           tonalCenter,
           resolved.homeMidi
         );
+      } else {
+        const rootPitchClass = chord.pitches[chord.rootPositionIndex] % 12;
+        voiced = computeTiltVoicing(
+          structure,
+          rootPitchClass,
+          tilt,
+          octaveRange,
+          tonalCenter
+        );
       }
 
-      const rootPitchClass = chord.pitches[chord.rootPositionIndex] % 12;
-      return computeTiltVoicing(
-        structure,
-        rootPitchClass,
-        tilt,
-        octaveRange,
-        tonalCenter
-      );
+      return borrowingLogic.filterVoicingMutes(voiced, mutedPitchClasses);
     },
     [tonalCenterRef]
   );
@@ -120,18 +130,38 @@ export function useChordPlayback({
     []
   );
 
+  const resolvePlaybackChord = useCallback(
+    (chord: Chord): Chord => {
+      if (!isElementalName(chord.name)) return chord;
+      return resolveElementalPlayback(
+        chord,
+        tonalCenterRef.current,
+        chordManager.getOctaveRange(),
+        previousChordRef.current
+      ).chord;
+    },
+    [tonalCenterRef]
+  );
+
   const playAndDisplayChord = useCallback(
     (chord: Chord, state: BorrowingState) => {
+      const playbackChord = resolvePlaybackChord(chord);
       if (playStyle === 'tilt') {
-        const pitches = computeTiltPitches(chord, state);
+        const pitches = computeTiltPitches(playbackChord, state);
         playPitches(pitches, playStyle);
         return;
       }
 
-      const pitches = computeStaticPitches(chord, state);
+      const pitches = computeStaticPitches(playbackChord, state);
       playPitches(pitches, playStyle);
     },
-    [playStyle, computeTiltPitches, computeStaticPitches, playPitches]
+    [
+      playStyle,
+      resolvePlaybackChord,
+      computeTiltPitches,
+      computeStaticPitches,
+      playPitches,
+    ]
   );
 
   useEffect(() => {

--- a/web/src/hooks/useChordPlayback.ts
+++ b/web/src/hooks/useChordPlayback.ts
@@ -1,183 +1,224 @@
-import { useState, useEffect, useRef, useCallback, type RefObject } from 'react';
-import { chordManager, type Chord } from '../music/ChordManager';
-import { borrowingLogic, type BorrowingState } from '../music/BorrowingLogic';
-import {
-  computeTiltVoicing,
-  tiltSampleFromLevels,
-  type TiltSample,
-} from '../music/TiltVoicingEngine';
-import { triggerHaptic } from '../audio/haptics';
-import { audioEngine } from '../audio/AudioEngine';
-import { unlockIosMediaChannel } from '../audio/iosMediaChannel';
-import type { PlayStyle } from '../context/types';
-
-interface UseChordPlaybackOptions {
-  getBorrowingStateForChord: (
-    chordName: string,
-    currentGlobalState: BorrowingState
-  ) => BorrowingState;
-  borrowingStateRef: RefObject<BorrowingState>;
-  setBorrowingState: (state: BorrowingState) => void;
-  setSelectedChord: (chord: Chord | null) => void;
-  tiltRef: RefObject<TiltSample>;
-  staticVoicingLevelRef: RefObject<number>;
-  staticInversionLevelRef: RefObject<number>;
-}
-
-export function useChordPlayback({
-  getBorrowingStateForChord,
-  borrowingStateRef,
-  setBorrowingState,
-  setSelectedChord,
-  tiltRef,
-  staticVoicingLevelRef,
-  staticInversionLevelRef,
-}: UseChordPlaybackOptions) {
-  const [playStyle, setPlayStyle] = useState<PlayStyle>('drone');
-  const [activePitches, setActivePitches] = useState<(number | null)[]>([]);
-
-  const isPointerDownRef = useRef(false);
-  const playStyleRef = useRef(playStyle);
-
-  useEffect(() => {
-    playStyleRef.current = playStyle;
-    audioEngine.releaseActiveNotes();
-    isPointerDownRef.current = false;
-  }, [playStyle]);
-
-  const computeVoicedPitches = useCallback(
-    (chord: Chord, state: BorrowingState, tilt: TiltSample): number[] => {
-      const structure = borrowingLogic.generatePitchStructure(chord, state);
-      const rootPitchClass = chord.pitches[chord.rootPositionIndex] % 12;
-      return computeTiltVoicing(
-        structure,
-        rootPitchClass,
-        tilt,
-        chordManager.getOctaveRange()
-      );
-    },
-    []
-  );
-
-  const computeTiltPitches = useCallback(
-    (chord: Chord, state: BorrowingState): number[] =>
-      computeVoicedPitches(chord, state, tiltRef.current),
-    [computeVoicedPitches, tiltRef]
-  );
-
-  const computeStaticPitches = useCallback(
-    (chord: Chord, state: BorrowingState): number[] =>
-      computeVoicedPitches(
-        chord,
-        state,
-        tiltSampleFromLevels(
-          staticVoicingLevelRef.current,
-          staticInversionLevelRef.current
-        )
-      ),
-    [computeVoicedPitches, staticVoicingLevelRef, staticInversionLevelRef]
-  );
-
-  const playPitches = useCallback(
-    (pitches: number[], style: PlayStyle) => {
-      setActivePitches(pitches);
-      if (pitches.length === 0) return;
-
-      if (style === 'click_and_hold') {
-        audioEngine.playNotes(pitches, '2n');
-      } else {
-        audioEngine.triggerAttack(pitches);
-      }
-    },
-    []
-  );
-
-  const playAndDisplayChord = useCallback(
-    (chord: Chord, state: BorrowingState) => {
-      if (playStyle === 'tilt') {
-        const pitches = computeTiltPitches(chord, state);
-        playPitches(pitches, playStyle);
-        return;
-      }
-
-      const pitches = computeStaticPitches(chord, state);
-      playPitches(pitches, playStyle);
-    },
-    [playStyle, computeTiltPitches, computeStaticPitches, playPitches]
-  );
-
-  useEffect(() => {
-    const handleGlobalPointerUp = () => {
-      if (isPointerDownRef.current) {
-        isPointerDownRef.current = false;
-        if (playStyleRef.current === 'click_and_hold') {
-          audioEngine.releaseActiveNotes();
-        }
-      }
-    };
-    window.addEventListener('pointerup', handleGlobalPointerUp);
-    window.addEventListener('pointercancel', handleGlobalPointerUp);
-    return () => {
-      window.removeEventListener('pointerup', handleGlobalPointerUp);
-      window.removeEventListener('pointercancel', handleGlobalPointerUp);
-    };
-  }, []);
-
-  const applyChordWithBorrowing = (chord: Chord) => {
-    const newState = getBorrowingStateForChord(
-      chord.name,
-      borrowingStateRef.current
-    );
-    setBorrowingState(newState);
-
-    if (playStyle === 'tilt') {
-      const pitches = computeTiltPitches(chord, newState);
-      setActivePitches(pitches);
-      if (pitches.length > 0) {
-        triggerHaptic();
-        audioEngine.triggerAttack(pitches, true);
-      }
-      return newState;
-    }
-
-    const pitches = computeStaticPitches(chord, newState);
-    setActivePitches(pitches);
-    if (pitches.length > 0) {
-      audioEngine.triggerAttack(pitches);
-    }
-
-    return newState;
-  };
-
-  const handleChordPointerDown = (chord: Chord) => {
-    unlockIosMediaChannel();
-    setSelectedChord(chord);
-    isPointerDownRef.current = true;
-    applyChordWithBorrowing(chord);
-  };
-
-  const handleChordPointerUp = () => {
-    isPointerDownRef.current = false;
-    if (playStyleRef.current === 'click_and_hold') {
-      audioEngine.releaseActiveNotes();
-    }
-  };
-
-  const handleChordPointerEnter = (chord: Chord) => {
-    if (isPointerDownRef.current) {
-      setSelectedChord(chord);
-      applyChordWithBorrowing(chord);
-    }
-  };
-
-  return {
-    playStyle,
-    setPlayStyle,
-    activePitches,
-    playAndDisplayChord,
-    handleChordPointerDown,
-    handleChordPointerUp,
-    handleChordPointerEnter,
-  };
-}
-
+import { useState, useEffect, useRef, useCallback, type RefObject } from 'react';
+import { chordManager, type Chord } from '../music/ChordManager';
+import { borrowingLogic, type BorrowingState } from '../music/BorrowingLogic';
+import {
+  computeTiltVoicing,
+  tiltSampleFromLevels,
+  type TiltSample,
+} from '../music/TiltVoicingEngine';
+import { triggerHaptic } from '../audio/haptics';
+import { audioEngine } from '../audio/AudioEngine';
+import { unlockIosMediaChannel } from '../audio/iosMediaChannel';
+import type { PlayStyle } from '../context/types';
+import {
+  isElementalName,
+  resolveElementalPlayback,
+} from '../music/elementalRoot';
+
+interface UseChordPlaybackOptions {
+  getBorrowingStateForChord: (
+    chordName: string,
+    currentGlobalState: BorrowingState
+  ) => BorrowingState;
+  borrowingStateRef: RefObject<BorrowingState>;
+  setBorrowingState: (state: BorrowingState) => void;
+  setSelectedChord: (chord: Chord | null) => void;
+  tiltRef: RefObject<TiltSample>;
+  staticVoicingLevelRef: RefObject<number>;
+  staticInversionLevelRef: RefObject<number>;
+  tonalCenterRef: RefObject<number>;
+}
+
+export function useChordPlayback({
+  getBorrowingStateForChord,
+  borrowingStateRef,
+  setBorrowingState,
+  setSelectedChord,
+  tiltRef,
+  staticVoicingLevelRef,
+  staticInversionLevelRef,
+  tonalCenterRef,
+}: UseChordPlaybackOptions) {
+  const [playStyle, setPlayStyle] = useState<PlayStyle>('drone');
+  const [activePitches, setActivePitches] = useState<(number | null)[]>([]);
+
+  const isPointerDownRef = useRef(false);
+  const playStyleRef = useRef(playStyle);
+  const previousChordRef = useRef<Chord | null>(null);
+
+  useEffect(() => {
+    playStyleRef.current = playStyle;
+    audioEngine.releaseActiveNotes();
+    isPointerDownRef.current = false;
+  }, [playStyle]);
+
+  const computeVoicedPitches = useCallback(
+    (chord: Chord, state: BorrowingState, tilt: TiltSample): number[] => {
+      const structure = borrowingLogic.generatePitchStructure(chord, state);
+      const tonalCenter = tonalCenterRef.current;
+      const octaveRange = chordManager.getOctaveRange();
+
+      if (isElementalName(chord.name)) {
+        const resolved = resolveElementalPlayback(
+          chord,
+          tonalCenter,
+          octaveRange,
+          previousChordRef.current
+        );
+        return computeTiltVoicing(
+          structure,
+          resolved.rootPitchClass,
+          tilt,
+          octaveRange,
+          tonalCenter,
+          resolved.homeMidi
+        );
+      }
+
+      const rootPitchClass = chord.pitches[chord.rootPositionIndex] % 12;
+      return computeTiltVoicing(
+        structure,
+        rootPitchClass,
+        tilt,
+        octaveRange,
+        tonalCenter
+      );
+    },
+    [tonalCenterRef]
+  );
+
+  const computeTiltPitches = useCallback(
+    (chord: Chord, state: BorrowingState): number[] =>
+      computeVoicedPitches(chord, state, tiltRef.current),
+    [computeVoicedPitches, tiltRef]
+  );
+
+  const computeStaticPitches = useCallback(
+    (chord: Chord, state: BorrowingState): number[] =>
+      computeVoicedPitches(
+        chord,
+        state,
+        tiltSampleFromLevels(
+          staticVoicingLevelRef.current,
+          staticInversionLevelRef.current
+        )
+      ),
+    [computeVoicedPitches, staticVoicingLevelRef, staticInversionLevelRef]
+  );
+
+  const playPitches = useCallback(
+    (pitches: number[], style: PlayStyle) => {
+      setActivePitches(pitches);
+      if (pitches.length === 0) return;
+
+      if (style === 'click_and_hold') {
+        audioEngine.playNotes(pitches, '2n');
+      } else {
+        audioEngine.triggerAttack(pitches);
+      }
+    },
+    []
+  );
+
+  const playAndDisplayChord = useCallback(
+    (chord: Chord, state: BorrowingState) => {
+      if (playStyle === 'tilt') {
+        const pitches = computeTiltPitches(chord, state);
+        playPitches(pitches, playStyle);
+        return;
+      }
+
+      const pitches = computeStaticPitches(chord, state);
+      playPitches(pitches, playStyle);
+    },
+    [playStyle, computeTiltPitches, computeStaticPitches, playPitches]
+  );
+
+  useEffect(() => {
+    const handleGlobalPointerUp = () => {
+      if (isPointerDownRef.current) {
+        isPointerDownRef.current = false;
+        if (playStyleRef.current === 'click_and_hold') {
+          audioEngine.releaseActiveNotes();
+        }
+      }
+    };
+    window.addEventListener('pointerup', handleGlobalPointerUp);
+    window.addEventListener('pointercancel', handleGlobalPointerUp);
+    return () => {
+      window.removeEventListener('pointerup', handleGlobalPointerUp);
+      window.removeEventListener('pointercancel', handleGlobalPointerUp);
+    };
+  }, []);
+
+  const applyChordWithBorrowing = (chord: Chord) => {
+    const newState = getBorrowingStateForChord(
+      chord.name,
+      borrowingStateRef.current
+    );
+    setBorrowingState(newState);
+
+    const tonalCenter = tonalCenterRef.current;
+    const octaveRange = chordManager.getOctaveRange();
+    const displayChord = isElementalName(chord.name)
+      ? resolveElementalPlayback(
+          chord,
+          tonalCenter,
+          octaveRange,
+          previousChordRef.current
+        ).chord
+      : chord;
+
+    if (playStyle === 'tilt') {
+      const pitches = computeTiltPitches(displayChord, newState);
+      previousChordRef.current = chord;
+      setSelectedChord(displayChord);
+      setActivePitches(pitches);
+      if (pitches.length > 0) {
+        triggerHaptic();
+        audioEngine.triggerAttack(pitches, true);
+      }
+      return newState;
+    }
+
+    const pitches = computeStaticPitches(displayChord, newState);
+    previousChordRef.current = chord;
+    setSelectedChord(displayChord);
+    setActivePitches(pitches);
+    if (pitches.length > 0) {
+      audioEngine.triggerAttack(pitches);
+    }
+
+    return newState;
+  };
+
+  const handleChordPointerDown = (chord: Chord) => {
+    unlockIosMediaChannel();
+    isPointerDownRef.current = true;
+    applyChordWithBorrowing(chord);
+  };
+
+  const handleChordPointerUp = () => {
+    isPointerDownRef.current = false;
+    if (playStyleRef.current === 'click_and_hold') {
+      audioEngine.releaseActiveNotes();
+    }
+  };
+
+  const handleChordPointerEnter = (chord: Chord) => {
+    if (isPointerDownRef.current) {
+      applyChordWithBorrowing(chord);
+    }
+  };
+
+  return {
+    playStyle,
+    setPlayStyle,
+    activePitches,
+    playAndDisplayChord,
+    handleChordPointerDown,
+    handleChordPointerUp,
+    handleChordPointerEnter,
+  };
+}
+

--- a/web/src/hooks/useChordPlayback.ts
+++ b/web/src/hooks/useChordPlayback.ts
@@ -25,7 +25,7 @@ interface UseChordPlaybackOptions {
   setSelectedChord: (chord: Chord | null) => void;
   tiltRef: RefObject<TiltSample>;
   staticVoicingLevelRef: RefObject<number>;
-  staticInversionLevelRef: RefObject<number>;
+  staticPositionLevelRef: RefObject<number>;
   tonalCenterRef: RefObject<number>;
 }
 
@@ -36,7 +36,7 @@ export function useChordPlayback({
   setSelectedChord,
   tiltRef,
   staticVoicingLevelRef,
-  staticInversionLevelRef,
+  staticPositionLevelRef,
   tonalCenterRef,
 }: UseChordPlaybackOptions) {
   const [playStyle, setPlayStyle] = useState<PlayStyle>('drone');
@@ -100,10 +100,10 @@ export function useChordPlayback({
         state,
         tiltSampleFromLevels(
           staticVoicingLevelRef.current,
-          staticInversionLevelRef.current
+          staticPositionLevelRef.current
         )
       ),
-    [computeVoicedPitches, staticVoicingLevelRef, staticInversionLevelRef]
+    [computeVoicedPitches, staticVoicingLevelRef, staticPositionLevelRef]
   );
 
   const playPitches = useCallback(

--- a/web/src/hooks/useDeviceTilt.ts
+++ b/web/src/hooks/useDeviceTilt.ts
@@ -20,10 +20,17 @@ interface PermissionedOrientationEvent {
 const SMOOTHING_ALPHA = 0.25; // exponential moving average weight per event
 const READOUT_INTERVAL_MS = 150; // throttle for the React-visible sample
 
+const pitchTiltFromBeta = (beta: number): number => {
+  const norm = beta / 90;
+  if (norm > 0) return -Math.min(norm, 1);
+  if (norm < 0) return Math.min(-norm, 1);
+  return 0;
+};
+
 /**
  * Reads device orientation and exposes it as a normalized tilt sample in the
- * engine's coordinate space (see TiltVoicingEngine): both axes in [-1, 0],
- * where 0 is flat.
+ * engine's coordinate space (see TiltVoicingEngine): x in [-1, 0], y in
+ * [-1, 1], where 0 is flat on each axis.
  *
  * deviceorientation angles are used rather than devicemotion acceleration
  * because the angles are sign-consistent across browsers (iOS has a known
@@ -31,8 +38,9 @@ const READOUT_INTERVAL_MS = 150; // throttle for the React-visible sample
  *
  * - x: roll magnitude (|gamma| / 90), so either roll direction narrows the
  *   voicing. Fully vertical maps to -1.
- * - y: chest-ward pitch (beta / 90, positive beta only), selecting parallel
- *   inversions on the chord tone ladder.
+ * - y: chest-ward pitch (beta / 90, positive beta) maps to y in [-1, 0];
+ *   away-from-chest (negative beta) maps to y in (0, 1], selecting lower
+ *   ladder positions in reverse order (4th, 3rd, 2nd).
  *
  * onLevelChange fires whenever the quantized voicing level (the step pair
  * from mapTiltToPositions) changes, e.g. to drive haptic feedback.
@@ -77,13 +85,13 @@ export function useDeviceTilt(onLevelChange?: () => void) {
     smoothed.beta += SMOOTHING_ALPHA * (beta - smoothed.beta);
 
     const x = -Math.min(Math.abs(smoothed.gamma) / 90, 1);
-    const y = -Math.min(Math.max(smoothed.beta / 90, 0), 1);
+    const y = pitchTiltFromBeta(smoothed.beta);
     tiltRef.current = { x, y };
 
     // Level detection uses raw angles so haptic ticks are not delayed by
     // the display smoothing filter.
     const xRaw = -Math.min(Math.abs(gamma) / 90, 1);
-    const yRaw = -Math.min(Math.max(beta / 90, 0), 1);
+    const yRaw = pitchTiltFromBeta(beta);
     rawTiltRef.current = { x: xRaw, y: yRaw };
     const level = mapTiltToPositions(rawTiltRef.current);
     const lastLevel = lastLevelRef.current;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -289,8 +289,8 @@ body {
   }
 
   .diagram-overlay-pill--bottom-left {
-    padding: 6px 10px;
-    gap: 2px;
+    padding: 8px 10px;
+    gap: 3px;
   }
 
   .diagram-overlay-pill--bottom-left .diagram-overlay-pill__value {
@@ -425,6 +425,20 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .clock-container.mobile-overlay .playing-notes {
+    font-size: var(--overlay-subtitle-size, 12px) !important;
+    color: var(--text-secondary);
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+
+  .diagram-overlay-pill__sizer--block .playing-notes {
+    font-size: var(--overlay-subtitle-size, 12.5px);
   }
 
   .clock-container.mobile-overlay .chemistry-formula {
@@ -784,7 +798,7 @@ input[type="range"] {
 .clock-svg {
   width: 100%;
   height: 100%;
-  max-height: calc(100% - 60px); /* account for info text */
+  max-height: calc(100% - 72px); /* account for info text */
   min-height: 0;
   margin: 0 auto;
   display: block;
@@ -797,6 +811,12 @@ input[type="range"] {
 }
 
 .traditional-name {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  word-break: break-word;
+}
+
+.playing-notes {
   color: var(--text-secondary);
   font-size: 0.88rem;
 }

--- a/web/src/layout.test.tsx
+++ b/web/src/layout.test.tsx
@@ -76,9 +76,9 @@ describe('Responsive Layout CSS', () => {
     expect(phoneBlock).not.toMatch(/\.diagram-overlay-pill\.clock-pill/);
   });
 
-  it('should anchor voicing and inversion pills to top corners on mobile', () => {
+  it('should anchor voicing and position pills to top corners on mobile', () => {
     const phoneStart = cssContent.search(phoneLayoutPattern);
-    const phoneBlock = cssContent.slice(phoneStart, phoneStart + 6000);
+    const phoneBlock = cssContent.slice(phoneStart, phoneStart + 8000);
     expect(phoneBlock).toMatch(/\.diagram-overlay-pill--top-left\s*\{[^}]*left:/);
     expect(phoneBlock).toMatch(
       /\.diagram-overlay-pill--top-right\s*\{[^}]*right:/,

--- a/web/src/music/BorrowingLogic.test.ts
+++ b/web/src/music/BorrowingLogic.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { BorrowingLogic, getInitialBorrowingState } from './BorrowingLogic';
 import { chordManager } from './ChordManager';
 
 describe('BorrowingLogic', () => {
   const logic = new BorrowingLogic();
+
+  beforeEach(() => {
+    chordManager.setTonalCenterOffset(0);
+  });
 
   const firePitches = [62, 65, 68, 71]; // D4, F4, Ab4, B4
 
@@ -28,6 +32,103 @@ describe('BorrowingLogic', () => {
     it('wraps to the highest pitch class in the previous octave when none lower', () => {
       // D4 (62) -> B4 in previous octave (59)
       expect(logic.findNextLowerNote(62, firePitches)).toBe(59);
+    });
+  });
+
+  describe('getRootPositionMapping', () => {
+    it('maps Branch at C by harmonic degree', () => {
+      const branch = chordManager.getChordByName('Branch')!;
+      expect(branch.pitches).toEqual([0, 4, 7, 9]);
+      expect(branch.rootPositionIndex).toBe(0);
+      expect(logic.getRootPositionMapping(branch)).toEqual({
+        1: 0,
+        2: 1,
+        3: 2,
+        4: 3,
+      });
+    });
+
+    it('maps Brother Branch at C with root on dictionary first pitch', () => {
+      const bro = chordManager.getChordByName('Brother Branch')!;
+      expect(bro.pitches).toEqual([0, 3, 7, 10]);
+      expect(bro.rootPositionIndex).toBe(1);
+      expect(logic.getRootPositionMapping(bro)).toEqual({
+        1: 1,
+        2: 2,
+        3: 3,
+        4: 0,
+      });
+    });
+  });
+
+  describe('generatePitchStructure', () => {
+    it('nulls exactly one slot when each Branch voice is muted', () => {
+      const branch = chordManager.getChordByName('Branch')!;
+      const allOn = logic.generatePitchStructure(
+        branch,
+        getInitialBorrowingState()
+      );
+      expect(allOn).toEqual([0, 4, 7, 9]);
+
+      const muteRoot = getInitialBorrowingState();
+      muteRoot.noteStates[1] = 'off';
+      expect(logic.generatePitchStructure(branch, muteRoot)).toEqual([
+        null,
+        4,
+        7,
+        9,
+      ]);
+
+      const muteThird = getInitialBorrowingState();
+      muteThird.noteStates[2] = 'off';
+      expect(logic.generatePitchStructure(branch, muteThird)).toEqual([
+        0,
+        null,
+        7,
+        9,
+      ]);
+
+      const muteFifth = getInitialBorrowingState();
+      muteFifth.noteStates[3] = 'off';
+      expect(logic.generatePitchStructure(branch, muteFifth)).toEqual([
+        0,
+        4,
+        null,
+        9,
+      ]);
+
+      const muteSixth = getInitialBorrowingState();
+      muteSixth.noteStates[4] = 'off';
+      expect(logic.generatePitchStructure(branch, muteSixth)).toEqual([
+        0,
+        4,
+        7,
+        null,
+      ]);
+    });
+
+    it('skips borrowing on muted lines in pitch structure', () => {
+      const branch = chordManager.getChordByName('Branch')!;
+      const state = getInitialBorrowingState();
+      state.noteStates[1] = 'off';
+      state.circlePositions[1] = 'up';
+      state.borrowingDirections[1] = 'up';
+
+      const structure = logic.generatePitchStructure(branch, state);
+      expect(structure[0]).toBeNull();
+      expect(structure[1]).toBe(4);
+    });
+
+    it('getMutedPitchClasses uses borrowed pitch when line is muted', () => {
+      const branch = chordManager.getChordByName('Branch')!;
+      const state = getInitialBorrowingState();
+      state.noteStates[1] = 'off';
+      state.circlePositions[1] = 'up';
+      state.borrowingDirections[1] = 'up';
+
+      const muted = logic.getMutedPitchClasses(branch, state);
+      expect(muted.has(0)).toBe(false);
+      expect(muted.has(2)).toBe(true);
     });
   });
 

--- a/web/src/music/BorrowingLogic.ts
+++ b/web/src/music/BorrowingLogic.ts
@@ -94,43 +94,99 @@ export class BorrowingLogic {
     return chordManager.applyVoicing(this.generatePitchStructure(chord, state));
   }
 
+  /** Pitch classes to drop from a voiced chord when voice lines are muted. */
+  public getMutedPitchClasses(chord: Chord, state: BorrowingState): Set<number> {
+    const borrowedPitches = this.applyBorrowing(chord, state, true);
+    const rootPositionMapping = this.getRootPositionMapping(chord);
+    const muted = new Set<number>();
+
+    for (let line = 1; line <= 4; line++) {
+      if (state.noteStates[line] !== 'off') continue;
+
+      const noteIndex = rootPositionMapping[line];
+      if (noteIndex < borrowedPitches.length) {
+        muted.add(((borrowedPitches[noteIndex] % 12) + 12) % 12);
+      }
+    }
+
+    return muted;
+  }
+
+  /** Full 4-slot structure for tilt voicing (borrowing on, all voices on). */
+  public generatePitchStructureForVoicing(
+    chord: Chord,
+    state: BorrowingState
+  ): (number | null)[] {
+    const borrowedPitches = this.applyBorrowing(chord, state, true);
+    const rootPositionMapping = this.getRootPositionMapping(chord);
+    const fullPitchStructure: (number | null)[] = [null, null, null, null];
+
+    for (let line = 1; line <= 4; line++) {
+      const noteIndex = rootPositionMapping[line];
+      if (noteIndex < borrowedPitches.length) {
+        fullPitchStructure[noteIndex] = borrowedPitches[noteIndex];
+      }
+    }
+
+    return fullPitchStructure;
+  }
+
+  public filterVoicingMutes(
+    voicedPitches: number[],
+    mutedPitchClasses: Set<number>
+  ): number[] {
+    if (mutedPitchClasses.size === 0) return voicedPitches;
+    return voicedPitches.filter(
+      (pitch) => !mutedPitchClasses.has(((pitch % 12) + 12) % 12)
+    );
+  }
+
+  private applyBorrowing(
+    chord: Chord,
+    state: BorrowingState,
+    ignoreMute: boolean
+  ): number[] {
+    const borrowedPitches = [...chord.pitches];
+    const oppositeElement = ELEMENTAL_RELATIONSHIPS[chord.name]?.[0];
+
+    if (!oppositeElement) return borrowedPitches;
+
+    const oppositeChord = chordManager.getElementalChord(oppositeElement);
+    if (!oppositeChord) return borrowedPitches;
+
+    const oppositePitches = oppositeChord.pitches;
+    const rootPositionMapping = this.getRootPositionMapping(chord);
+
+    for (let line = 1; line <= 4; line++) {
+      if (!ignoreMute && state.noteStates[line] === 'off') continue;
+
+      if (state.circlePositions[line] !== 'line') {
+        const direction = state.borrowingDirections[line];
+        const targetNoteIndex = rootPositionMapping[line];
+
+        if (targetNoteIndex < borrowedPitches.length) {
+          const targetPitch = borrowedPitches[targetNoteIndex];
+          let replacement = targetPitch;
+
+          if (direction === 'up') {
+            replacement = this.findNextHigherNote(targetPitch, oppositePitches);
+          } else if (direction === 'down') {
+            replacement = this.findNextLowerNote(targetPitch, oppositePitches);
+          }
+
+          borrowedPitches[targetNoteIndex] = replacement;
+        }
+      }
+    }
+
+    return borrowedPitches;
+  }
+
   // Pre-voicing pitch structure: borrowing applied, voices toggled off as
   // nulls, no octave-range or drop-voicing offsets. Used directly by the
   // tilt play style, which voices chords itself.
   public generatePitchStructure(chord: Chord, state: BorrowingState): (number | null)[] {
-    const borrowedPitches = [...chord.pitches];
-
-    const oppositeElement = ELEMENTAL_RELATIONSHIPS[chord.name]?.[0];
-
-    if (oppositeElement) {
-      const oppositeChord = chordManager.getElementalChord(oppositeElement);
-      if (oppositeChord) {
-        const oppositePitches = oppositeChord.pitches;
-        const rootPositionMapping = this.getRootPositionMapping(chord);
-
-        for (let line = 1; line <= 4; line++) {
-          if (state.noteStates[line] === 'off') continue;
-
-          if (state.circlePositions[line] !== 'line') {
-            const direction = state.borrowingDirections[line];
-            const targetNoteIndex = rootPositionMapping[line];
-
-            if (targetNoteIndex < borrowedPitches.length) {
-              const targetPitch = borrowedPitches[targetNoteIndex];
-              let replacement = targetPitch;
-
-              if (direction === 'up') {
-                replacement = this.findNextHigherNote(targetPitch, oppositePitches);
-              } else if (direction === 'down') {
-                replacement = this.findNextLowerNote(targetPitch, oppositePitches);
-              }
-
-              borrowedPitches[targetNoteIndex] = replacement;
-            }
-          }
-        }
-      }
-    }
+    const borrowedPitches = this.applyBorrowing(chord, state, false);
 
     const fullPitchStructure: (number | null)[] = [null, null, null, null];
     const rootPositionMapping = this.getRootPositionMapping(chord);

--- a/web/src/music/ChordManager.test.ts
+++ b/web/src/music/ChordManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ChordManager } from './ChordManager';
-import { DEFAULT_TONAL_CENTER_OFFSET } from './config';
+import { DEFAULT_TONAL_CENTER_OFFSET, NOTE_NAMES_FLAT } from './config';
 
 describe('ChordManager', () => {
   let manager: ChordManager;
@@ -66,5 +66,61 @@ describe('ChordManager', () => {
     const after = manager.getChordByName('Earth')!.pitches;
 
     expect(after).not.toEqual(before);
+  });
+
+  describe('elemental diminished roots', () => {
+    const cases = [
+      {
+        tonalCenter: 0,
+        earth: 6,
+        wind: 4,
+        fire: 11,
+      },
+      {
+        tonalCenter: 2,
+        earth: 8,
+        wind: 6,
+        fire: 1,
+      },
+      {
+        tonalCenter: 10,
+        earth: 4,
+        wind: 2,
+        fire: 9,
+      },
+    ];
+
+    for (const { tonalCenter, earth, wind, fire } of cases) {
+      it(`maps Earth/Wind/Fire to contrary-motion dim7 roots at tonal center ${tonalCenter}`, () => {
+        manager.setTonalCenterOffset(tonalCenter);
+
+        const earthChord = manager.getChordByName('Earth')!;
+        const windChord = manager.getChordByName('Wind')!;
+        const fireChord = manager.getChordByName('Fire')!;
+
+        const earthRoot =
+          earthChord.pitches[earthChord.rootPositionIndex] % 12;
+        const windRoot = windChord.pitches[windChord.rootPositionIndex] % 12;
+        const fireRoot = fireChord.pitches[fireChord.rootPositionIndex] % 12;
+
+        expect(earthRoot).toBe(earth);
+        expect(windRoot).toBe(wind);
+        expect(fireRoot).toBe(fire);
+
+        expect(earthChord.traditionalName).toBe(
+          `${NOTE_NAMES_FLAT[earthRoot]} dim7`
+        );
+        expect(windChord.traditionalName).toBe(
+          `${NOTE_NAMES_FLAT[windRoot]} dim7`
+        );
+        expect(fireChord.traditionalName).toBe(
+          `${NOTE_NAMES_FLAT[fireRoot]} dim7`
+        );
+
+        for (const chord of [earthChord, windChord, fireChord]) {
+          expect(chord.pitches.every(p => p >= 0 && p < 12)).toBe(true);
+        }
+      });
+    }
   });
 });

--- a/web/src/music/ChordManager.ts
+++ b/web/src/music/ChordManager.ts
@@ -9,6 +9,12 @@ import {
   DEFAULT_OCTAVE_RANGE,
   DEFAULT_VOICING
 } from './config';
+import {
+  isElementalName,
+  getDefaultElementalRoot,
+  findRootPositionIndex,
+  elementalTraditionalName,
+} from './elementalRoot';
 
 export interface Chord {
   name: string;
@@ -51,7 +57,9 @@ export class ChordManager {
   private createChord(name: string, pitches: number[]): Chord {
     const rootPitchClass = pitches[0] % 12;
 
-    const transposedPitches = pitches.map(p => (p % 12) + (this.tonalCenterOffset % 12));
+    const transposedPitches = pitches.map(
+      p => ((p % 12) + (this.tonalCenterOffset % 12)) % 12
+    );
 
     const chordQualityMap: Record<string, string> = {
       "Earth": " dim7", "Wind": " dim7",
@@ -71,18 +79,25 @@ export class ChordManager {
     }
 
     const rootNote = NOTE_NAMES_FLAT[transposedPitches[0] % 12];
-    const traditionalName = rootNote + quality;
+    let traditionalName = rootNote + quality;
 
     transposedPitches.sort((a, b) => a - b);
 
-    const transposedRootPitchClass = (rootPitchClass + (this.tonalCenterOffset % 12)) % 12;
-    let rootPositionIndex = 0;
-    for (let i = 0; i < transposedPitches.length; i++) {
-      if (transposedPitches[i] % 12 === transposedRootPitchClass) {
-        rootPositionIndex = i;
-        break;
-      }
+    let transposedRootPitchClass =
+      (rootPitchClass + (this.tonalCenterOffset % 12)) % 12;
+
+    if (isElementalName(name)) {
+      transposedRootPitchClass = getDefaultElementalRoot(
+        name,
+        this.tonalCenterOffset
+      );
+      traditionalName = elementalTraditionalName(transposedRootPitchClass);
     }
+
+    const rootPositionIndex = findRootPositionIndex(
+      transposedPitches,
+      transposedRootPitchClass
+    );
 
     return {
       name,

--- a/web/src/music/TiltVoicingEngine.ts
+++ b/web/src/music/TiltVoicingEngine.ts
@@ -39,7 +39,6 @@ const MAX_CHAIN_WIDTH = 9;
 // max 5 voices). Keyed by chain width; values are 1-indexed chain positions
 // to skip, counted from the bottom.
 const THINNING_RULES: Record<number, number[]> = {
-  5: [3],          // octave chord
   6: [2, 5],       // drop 2
   7: [3, 6],       // drop 3
   8: [2, 4, 7],    // drop 2 and 4
@@ -270,19 +269,27 @@ export function obliqueMotion(
  * pitchStructure: pre-voicing pitches from BorrowingLogic (4 slots, nulls
  * for voices toggled off). rootPitchClass: pitch class of the chord root.
  * octaveRange: the app's octave range setting, used to place the register.
+ * tonalCenter: selected root/key pitch class; anchors home register so
+ * elemental chords stay in a continuous register when roots wrap mod 12.
+ * homeMidiOverride: when set, uses this pivot instead of the default formula
+ * (used for elemental contrary-motion anchoring).
  */
 export function computeTiltVoicing(
   pitchStructure: (number | null)[],
   rootPitchClass: number,
   tilt: TiltSample,
-  octaveRange: number
+  octaveRange: number,
+  tonalCenter: number,
+  homeMidiOverride?: number
 ): number[] {
   const cycle = buildToneCycle(pitchStructure, rootPitchClass);
   if (cycle.length === 0) return [];
 
-  // Home register: the chord root two octaves above the octave-range base,
-  // so the double octave chord below it spans the app's normal register.
-  const homeMidi = rootPitchClass + OCTAVE * (octaveRange + 2);
+  const homeMidi =
+    homeMidiOverride ??
+    (tonalCenter +
+      OCTAVE * (octaveRange + 2) +
+      ((rootPitchClass - tonalCenter + OCTAVE) % OCTAVE));
 
   const { parallelSteps } = mapTiltToPositions(tilt);
   const parallel = Math.min(parallelSteps, cycle.length - 1);

--- a/web/src/music/TiltVoicingEngine.ts
+++ b/web/src/music/TiltVoicingEngine.ts
@@ -6,8 +6,8 @@
 // post-borrowing chord, expressed as ascending semitone offsets from the
 // chord root. One ladder step equals one chord tone. Rolling the phone
 // expands the voicing in oblique motion from a pivot (alternating notes
-// above and below); pitching the phone toward the sky cycles parallel
-// inversions (each voice moves up one chord tone on the ladder).
+// above and below); pitching the phone cycles parallel positions on the
+// ladder (chest-ward raises the pivot, away-from-chest lowers it).
 //
 // The roll response is deliberately reversed from the Python original:
 // flat = widest voicing (double octave chord), fully vertical = single note.
@@ -15,9 +15,9 @@
 import { OCTAVE } from './config';
 
 export interface TiltSample {
-  // Normalized tilt, each axis in [-1, 0]. 0 = phone flat.
-  // x: roll toward vertical drives x to -1.
-  // y: pitch toward the sky (camera up) drives y to -1.
+  // Normalized tilt. 0 = phone flat on each axis.
+  // x: roll toward vertical drives x to -1 (range [-1, 0]).
+  // y: chest-ward pitch drives y to -1; away-from-chest drives y to +1.
   x: number;
   y: number;
 }
@@ -28,8 +28,13 @@ export const FLAT_TILT: TiltSample = { x: 0, y: 0 };
 // (Double Octave).
 const MAX_INPUT_STEPS = 8;
 
-// Four parallel levels (root through third inversion) on a 4-tone cycle.
+// Four named positions (1st through 4th) on a 4-tone cycle; static UI uses
+// indices 0..MAX_PARALLEL_STEPS. Tilt pitch adds one extra ladder step each
+// way so full tilt lands on 1st again (one cycle up or down).
 export const MAX_PARALLEL_STEPS = 3;
+
+/** Chest-ward / away-from-chest tilt steps at full pitch (±4 ladder steps). */
+export const MAX_TILT_PITCH_STEPS = MAX_PARALLEL_STEPS + 1;
 
 // Cap matching mnc.py: never build a chain wider than the double octave
 // chord.
@@ -84,38 +89,66 @@ export function ladderPitch(
 }
 
 /**
- * Quantized parallel inversion level (0 = root position) from pitch tilt.
+ * Signed ladder pivot step from pitch tilt.
+ * Chest-ward (y < 0): +1..+4; away-from-chest (y > 0): -1..-4; flat: 0.
+ * ±4 is one full tone-cycle (octave register) from center 1st.
  */
 export function parallelLevelFromTilt(tilt: TiltSample): number {
-  const y = clamp(tilt.y, -1, 0);
-  return Math.round(Math.abs(y) * MAX_PARALLEL_STEPS);
+  const y = clamp(tilt.y, -1, 1);
+  if (y === 0) return 0;
+  if (y < 0) {
+    return Math.round(Math.abs(y) * MAX_TILT_PITCH_STEPS);
+  }
+  const downSteps = Math.round(y * MAX_TILT_PITCH_STEPS);
+  return downSteps === 0 ? 0 : -downSteps;
 }
 
-export const TILT_INVERSION_LEVEL_NAMES = [
-  'Root',
-  'First',
-  'Second',
-  'Third',
+/** Map signed pivot steps to a 0-based position label index (1st..4th). */
+export function positionLabelIndexFromParallelSteps(steps: number): number {
+  const positionCount = MAX_PARALLEL_STEPS + 1;
+  if (steps >= 0) {
+    return steps % positionCount;
+  }
+  const abs = Math.abs(steps);
+  if (abs >= positionCount) return 0;
+  return MAX_PARALLEL_STEPS - abs + 1;
+}
+
+export const TILT_POSITION_MOBILE_LABELS = [
+  '1st',
+  '2nd',
+  '3rd',
+  '4th',
 ] as const;
 
-/** Desktop top-bar inversion select labels (no separate inversion title). */
-export const TILT_INVERSION_DESKTOP_LABELS = TILT_INVERSION_LEVEL_NAMES.map(
-  (name) => `${name} Inv.`,
+/** Desktop top-bar position select labels (no separate position title). */
+export const TILT_POSITION_DESKTOP_LABELS = TILT_POSITION_MOBILE_LABELS.map(
+  (name) => `${name} Pos.`,
 );
 
-export const TILT_INVERSION_MAX_LABEL = (
-  [...TILT_INVERSION_LEVEL_NAMES] as const
+export const TILT_POSITION_MAX_LABEL = (
+  [...TILT_POSITION_DESKTOP_LABELS] as const
 ).reduce(
   (longest, label) => (label.length > longest.length ? label : longest),
-  '' as (typeof TILT_INVERSION_LEVEL_NAMES)[number],
+  '' as (typeof TILT_POSITION_DESKTOP_LABELS)[number],
 );
 
+export type TiltPositionLabelVariant = 'mobile' | 'desktop';
+
 /**
- * Human-readable parallel inversion for the current pitch tilt.
+ * Human-readable parallel position for the current pitch tilt.
  */
-export function tiltInversionLevelName(tilt: TiltSample): string {
-  const level = parallelLevelFromTilt(tilt);
-  return TILT_INVERSION_LEVEL_NAMES[level] ?? 'Root';
+export function tiltPositionLevelName(
+  tilt: TiltSample,
+  variant: TiltPositionLabelVariant = 'mobile'
+): string {
+  const steps = parallelLevelFromTilt(tilt);
+  const idx = positionLabelIndexFromParallelSteps(steps);
+  const labels =
+    variant === 'desktop'
+      ? TILT_POSITION_DESKTOP_LABELS
+      : TILT_POSITION_MOBILE_LABELS;
+  return labels[idx] ?? TILT_POSITION_MOBILE_LABELS[0];
 }
 
 /**
@@ -123,8 +156,8 @@ export function tiltInversionLevelName(tilt: TiltSample): string {
  *
  * Roll (x) is REVERSED: flat (x = 0) selects the widest oblique voicing,
  * fully vertical (x = -1) selects Unison. Pitch (y) selects the parallel
- * inversion: flat = root (0), full sky tilt = third inversion
- * (MAX_PARALLEL_STEPS).
+ * position: flat = 1st (0); chest-ward = 2nd..4th..1st (+1..+4); away-from-chest
+ * = 4th..2nd..1st (-1..-4).
  */
 export function mapTiltToPositions(tilt: TiltSample): {
   inputSteps: number;
@@ -140,8 +173,8 @@ export function mapTiltToPositions(tilt: TiltSample): {
 /** Default static voicing level index (8 = Double Octave). */
 export const DEFAULT_STATIC_VOICING_LEVEL = MAX_INPUT_STEPS;
 
-/** Default static inversion level index (0 = Root). */
-export const DEFAULT_STATIC_INVERSION_LEVEL = 0;
+/** Default static position level index (0 = 1st). */
+export const DEFAULT_STATIC_POSITION_LEVEL = 0;
 
 /**
  * Build a discrete tilt sample for static mode UI controls.
@@ -154,7 +187,9 @@ export function tiltSampleFromLevels(
   const clampedParallel = clamp(parallelSteps, 0, MAX_PARALLEL_STEPS);
   const x = clampedInput / MAX_INPUT_STEPS - 1;
   const y =
-    clampedParallel === 0 ? 0 : -(clampedParallel / MAX_PARALLEL_STEPS);
+    clampedParallel === 0
+      ? 0
+      : -(clampedParallel / MAX_TILT_PITCH_STEPS);
   return { x, y };
 }
 
@@ -201,7 +236,7 @@ export const TILT_READOUT_MAX_LABEL = (
 );
 
 /**
- * Oblique chain width (1–9) implied by roll tilt. Pitch inversion does not
+ * Oblique chain width (1–9) implied by roll tilt. Pitch position does not
  * change width.
  */
 export function voicingWidthFromTilt(tilt: TiltSample): number {
@@ -264,7 +299,7 @@ export function obliqueMotion(
  * Compute the full tilt voicing for a chord.
  *
  * Parallel and oblique motion compose on the tone ladder: the pitch axis
- * sets the inversion (pivot position); roll selects the oblique chain width.
+ * sets the position (pivot); roll selects the oblique chain width.
  *
  * pitchStructure: pre-voicing pitches from BorrowingLogic (4 slots, nulls
  * for voices toggled off). rootPitchClass: pitch class of the chord root.
@@ -292,7 +327,8 @@ export function computeTiltVoicing(
       ((rootPitchClass - tonalCenter + OCTAVE) % OCTAVE));
 
   const { parallelSteps } = mapTiltToPositions(tilt);
-  const parallel = Math.min(parallelSteps, cycle.length - 1);
+  const maxPivot = cycle.length;
+  const pivot = clamp(parallelSteps, -maxPivot, maxPivot);
   const width = voicingWidthFromTilt(tilt);
-  return obliqueMotion(parallel, width, cycle, homeMidi);
+  return obliqueMotion(pivot, width, cycle, homeMidi);
 }

--- a/web/src/music/diagramMetadata.ts
+++ b/web/src/music/diagramMetadata.ts
@@ -67,4 +67,8 @@ export const CHORD_OVERLAY_MAX_NAME = BASE_GROUPS.flatMap((group) =>
 );
 
 /** Max subscript count for chord overlay width sizer (widest chemistry row). */
-export const CHORD_OVERLAY_MAX_CHEM_COUNT = 5;
+export const CHORD_OVERLAY_MAX_CHEM_COUNT = 4;
+
+/** Widest realistic playing-notes row for chord pill height/width sizer. */
+export const CHORD_OVERLAY_MAX_PLAYING_NOTES =
+  'C2 G2 Bb2 D3 F3 A3 C4';

--- a/web/src/music/elementChemistry.ts
+++ b/web/src/music/elementChemistry.ts
@@ -1,0 +1,35 @@
+export interface ElementFormula {
+  earth: number;
+  wind: number;
+  fire: number;
+}
+
+/**
+ * Count Earth / Wind / Fire weights for the chemistry readout.
+ *
+ * Each unique pitch class contributes at most once, so doubled roots in
+ * wide voicings (e.g. Bb3 and Bb4) do not inflate the subscripts.
+ */
+export function computeElementFormula(
+  activePitches: (number | null)[],
+  tonalCenter: number
+): ElementFormula | null {
+  const pitchClasses = new Set<number>();
+  for (const pitch of activePitches) {
+    if (pitch === null) continue;
+    pitchClasses.add(((pitch % 12) + 12) % 12);
+  }
+  if (pitchClasses.size === 0) return null;
+
+  let earth = 0;
+  let wind = 0;
+  let fire = 0;
+  for (const pitchClass of pitchClasses) {
+    const relPc = ((pitchClass - tonalCenter) + 12) % 12;
+    const rem = relPc % 3;
+    if (rem === 0) earth++;
+    else if (rem === 1) wind++;
+    else fire++;
+  }
+  return { earth, wind, fire };
+}

--- a/web/src/music/elementalRoot.test.ts
+++ b/web/src/music/elementalRoot.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChordManager } from './ChordManager';
+import {
+  getDefaultElementalRoot,
+  resolveElementalRoot,
+  resolveElementalPlayback,
+  computeChordHomeMidi,
+} from './elementalRoot';
+import {
+  computeTiltVoicing,
+  tiltSampleFromLevels,
+} from './TiltVoicingEngine';
+
+describe('elementalRoot', () => {
+  let manager: ChordManager;
+  const OCTAVE_RANGE = 3;
+
+  beforeEach(() => {
+    manager = new ChordManager();
+    manager.setTonalCenterOffset(10); // Bb
+  });
+
+  describe('default diminished names at Bb', () => {
+    it('names Earth E dim7, Wind D dim7, Fire A dim7', () => {
+      expect(getDefaultElementalRoot('Earth', 10)).toBe(4);
+      expect(getDefaultElementalRoot('Wind', 10)).toBe(2);
+      expect(getDefaultElementalRoot('Fire', 10)).toBe(9);
+
+      expect(manager.getChordByName('Earth')!.traditionalName).toBe('E dim7');
+      expect(manager.getChordByName('Wind')!.traditionalName).toBe('D dim7');
+      expect(manager.getChordByName('Fire')!.traditionalName).toBe('A dim7');
+    });
+  });
+
+  describe('contextual roots after opposite child', () => {
+    it('roots Fire at A dim7 after Branch (Bb maj6)', () => {
+      const branch = manager.getChordByName('Branch')!;
+      expect(resolveElementalRoot('Fire', 10, branch)).toBe(9);
+      expect(
+        resolveElementalPlayback(
+          manager.getChordByName('Fire')!,
+          10,
+          OCTAVE_RANGE,
+          branch
+        ).chord.traditionalName
+      ).toBe('A dim7');
+    });
+
+    it('roots Fire at Eb dim7 after Twin Branch (E maj6)', () => {
+      const twinBranch = manager.getChordByName('Twin Branch')!;
+      expect(resolveElementalRoot('Fire', 10, twinBranch)).toBe(3);
+      expect(
+        resolveElementalPlayback(
+          manager.getChordByName('Fire')!,
+          10,
+          OCTAVE_RANGE,
+          twinBranch
+        ).chord.traditionalName
+      ).toBe('Eb dim7');
+    });
+  });
+
+  describe('contrary motion voicing at Bb', () => {
+    it('places Fire unison one semitone below Branch unison', () => {
+      const branch = manager.getChordByName('Branch')!;
+      const fire = manager.getChordByName('Fire')!;
+      const branchRoot = branch.pitches[branch.rootPositionIndex] % 12;
+      const resolved = resolveElementalPlayback(
+        fire,
+        10,
+        OCTAVE_RANGE,
+        branch
+      );
+
+      const branchUnison = computeChordHomeMidi(branchRoot, 10, OCTAVE_RANGE);
+      const fireUnison = resolved.homeMidi;
+      expect(fireUnison).toBe(branchUnison - 1);
+    });
+
+    it('widens Branch unison to triad then Fire third with contrary motion', () => {
+      const branch = manager.getChordByName('Branch')!;
+      const fire = manager.getChordByName('Fire')!;
+      const branchRoot = branch.pitches[branch.rootPositionIndex] % 12;
+      const branchStructure = [...branch.pitches];
+
+      const branchUnison = computeTiltVoicing(
+        branchStructure,
+        branchRoot,
+        { x: -1, y: 0 },
+        OCTAVE_RANGE,
+        10
+      );
+      expect(branchUnison).toEqual([70]); // Bb4
+
+      const branchTriad = computeTiltVoicing(
+        branchStructure,
+        branchRoot,
+        tiltSampleFromLevels(2, 0),
+        OCTAVE_RANGE,
+        10
+      );
+      expect(branchTriad).toEqual([67, 70, 74]); // G4 Bb4 D5
+
+      const resolved = resolveElementalPlayback(
+        fire,
+        10,
+        OCTAVE_RANGE,
+        branch
+      );
+      const fireThird = computeTiltVoicing(
+        [...fire.pitches],
+        resolved.rootPitchClass,
+        tiltSampleFromLevels(1, 0),
+        OCTAVE_RANGE,
+        10,
+        resolved.homeMidi
+      );
+      expect(fireThird).toEqual([69, 72]); // A4 C5, one semitone below Branch pivot
+    });
+  });
+
+  describe('works at other tonal centers', () => {
+    it('defaults Fire to B dim7 at tonal center C', () => {
+      manager.setTonalCenterOffset(0);
+      expect(getDefaultElementalRoot('Fire', 0)).toBe(11);
+      expect(manager.getChordByName('Fire')!.traditionalName).toBe('B dim7');
+    });
+
+    it('roots Fire half step below Branch at tonal center D', () => {
+      manager.setTonalCenterOffset(2);
+      const branch = manager.getChordByName('Branch')!;
+      expect(resolveElementalRoot('Fire', 2, branch)).toBe(1);
+      expect(
+        resolveElementalPlayback(
+          manager.getChordByName('Fire')!,
+          2,
+          OCTAVE_RANGE,
+          branch
+        ).chord.traditionalName
+      ).toBe('Db dim7');
+    });
+  });
+});

--- a/web/src/music/elementalRoot.ts
+++ b/web/src/music/elementalRoot.ts
@@ -1,0 +1,166 @@
+import { ELEMENTAL_RELATIONSHIPS, NOTE_NAMES_FLAT, OCTAVE } from './config';
+import type { Chord } from './ChordManager';
+
+export const ELEMENTAL_NAMES = ['Earth', 'Wind', 'Fire'] as const;
+export type ElementalName = (typeof ELEMENTAL_NAMES)[number];
+
+/** First pitch class (C region) of the base child on each element's opposite edge. */
+const OPPOSITE_BASE_CHILD_ROOT_PC: Record<ElementalName, number> = {
+  Fire: 0, // Branch (Earth+Wind)
+  Earth: 7, // Smoke (Wind+Fire)
+  Wind: 5, // Glass (Fire+Earth)
+};
+
+export function isElementalName(name: string): name is ElementalName {
+  return (ELEMENTAL_NAMES as readonly string[]).includes(name);
+}
+
+export function getChordRootPitchClass(chord: Chord): number {
+  return chord.pitches[chord.rootPositionIndex] % 12;
+}
+
+/** Half step below a pitch class. */
+export function semitoneBelow(pitchClass: number): number {
+  return (pitchClass + 11) % 12;
+}
+
+/**
+ * Default diminished root for an element: one semitone below the root of the
+ * base child chord on the opposite triangle edge (Branch / Smoke / Glass).
+ */
+export function getDefaultElementalRoot(
+  element: ElementalName,
+  tonalCenter: number
+): number {
+  const oppositeChildRoot =
+    (OPPOSITE_BASE_CHILD_ROOT_PC[element] + tonalCenter) % 12;
+  return semitoneBelow(oppositeChildRoot);
+}
+
+/**
+ * Resolve the diminished root for an element. When the previously played chord
+ * borrows from this element, root one semitone below that child's root.
+ */
+export function resolveElementalRoot(
+  element: ElementalName,
+  tonalCenter: number,
+  previousChord: Chord | null
+): number {
+  if (previousChord) {
+    const opposite = ELEMENTAL_RELATIONSHIPS[previousChord.name]?.[0];
+    if (opposite === element) {
+      return semitoneBelow(getChordRootPitchClass(previousChord));
+    }
+  }
+  return getDefaultElementalRoot(element, tonalCenter);
+}
+
+export function elementalTraditionalName(rootPitchClass: number): string {
+  return `${NOTE_NAMES_FLAT[rootPitchClass]} dim7`;
+}
+
+export function findRootPositionIndex(
+  pitches: number[],
+  rootPitchClass: number
+): number {
+  for (let i = 0; i < pitches.length; i++) {
+    if (pitches[i] % 12 === rootPitchClass) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+/** Apply a resolved diminished root to an elemental chord for playback/display. */
+export function withElementalRoot(chord: Chord, rootPitchClass: number): Chord {
+  return {
+    ...chord,
+    rootPositionIndex: findRootPositionIndex(chord.pitches, rootPitchClass),
+    traditionalName: elementalTraditionalName(rootPitchClass),
+  };
+}
+
+/**
+ * Home MIDI for a chord root relative to the tonal center and octave range.
+ */
+export function computeChordHomeMidi(
+  rootPitchClass: number,
+  tonalCenter: number,
+  octaveRange: number
+): number {
+  return (
+    tonalCenter +
+    OCTAVE * (octaveRange + 2) +
+    ((rootPitchClass - tonalCenter + OCTAVE) % OCTAVE)
+  );
+}
+
+/** Signed semitone distance from one pitch class to another (never wraps past ±6). */
+function signedPitchClassDelta(fromPc: number, toPc: number): number {
+  const mod = (toPc - fromPc + OCTAVE) % OCTAVE;
+  return mod > 6 ? mod - OCTAVE : mod;
+}
+
+/**
+ * Pivot register for an elemental diminished chord so its unison sits at the
+ * correct signed semitone offset from the opposite child's pivot (contrary
+ * motion anchor).
+ */
+export function computeElementalHomeMidi(
+  elementalRootPitchClass: number,
+  tonalCenter: number,
+  octaveRange: number,
+  anchorChildRootPitchClass: number
+): number {
+  const childHome = computeChordHomeMidi(
+    anchorChildRootPitchClass,
+    tonalCenter,
+    octaveRange
+  );
+  return (
+    childHome +
+    signedPitchClassDelta(anchorChildRootPitchClass, elementalRootPitchClass)
+  );
+}
+
+export function resolveElementalPlayback(
+  chord: Chord,
+  tonalCenter: number,
+  octaveRange: number,
+  previousChord: Chord | null
+): {
+  chord: Chord;
+  rootPitchClass: number;
+  homeMidi: number;
+} {
+  const element = chord.name as ElementalName;
+  const rootPitchClass = resolveElementalRoot(
+    element,
+    tonalCenter,
+    previousChord
+  );
+
+  let anchorChildRoot: number;
+  if (
+    previousChord &&
+    ELEMENTAL_RELATIONSHIPS[previousChord.name]?.[0] === element
+  ) {
+    anchorChildRoot = getChordRootPitchClass(previousChord);
+  } else {
+    anchorChildRoot =
+      (OPPOSITE_BASE_CHILD_ROOT_PC[element] + tonalCenter) % 12;
+  }
+
+  const homeMidi = computeElementalHomeMidi(
+    rootPitchClass,
+    tonalCenter,
+    octaveRange,
+    anchorChildRoot
+  );
+
+  return {
+    chord: withElementalRoot(chord, rootPitchClass),
+    rootPitchClass,
+    homeMidi,
+  };
+}

--- a/web/src/music/formatPlayingNotes.test.ts
+++ b/web/src/music/formatPlayingNotes.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  midiToNoteName,
+  formatPlayingNotes,
+  formatChordReadout,
+} from './formatPlayingNotes';
+
+describe('midiToNoteName', () => {
+  it('maps MIDI 60 to C4', () => {
+    expect(midiToNoteName(60)).toBe('C4');
+  });
+
+  it('maps MIDI 58 to Bb3', () => {
+    expect(midiToNoteName(58)).toBe('Bb3');
+  });
+
+  it('uses flat spellings for black keys', () => {
+    expect(midiToNoteName(61)).toBe('Db4');
+    expect(midiToNoteName(63)).toBe('Eb4');
+  });
+});
+
+describe('formatPlayingNotes', () => {
+  it('sorts pitches ascending and joins with spaces', () => {
+    expect(formatPlayingNotes([69, 60, 64])).toBe('C4 E4 A4');
+  });
+
+  it('filters null entries', () => {
+    expect(formatPlayingNotes([60, null, 64])).toBe('C4 E4');
+  });
+
+  it('returns empty string when no pitches', () => {
+    expect(formatPlayingNotes([])).toBe('');
+    expect(formatPlayingNotes([null, null])).toBe('');
+  });
+});
+
+describe('formatChordReadout', () => {
+  it('returns placeholder when no chord name', () => {
+    expect(formatChordReadout(null, [60])).toBe('---');
+  });
+
+  it('returns traditional name only when no active pitches', () => {
+    expect(formatChordReadout('Bb maj6', [])).toBe('Bb maj6');
+  });
+
+  it('combines traditional name and playing notes', () => {
+    expect(formatChordReadout('Bb maj6', [58, 62, 65, 69])).toBe(
+      'Bb maj6 - Bb3 D4 F4 A4'
+    );
+  });
+});

--- a/web/src/music/formatPlayingNotes.ts
+++ b/web/src/music/formatPlayingNotes.ts
@@ -1,0 +1,33 @@
+import { NOTE_NAMES_FLAT } from './config';
+
+/** Convert a MIDI note number to flat spelling with octave (e.g. 60 -> C4). */
+export function midiToNoteName(midi: number): string {
+  const pitchClass = ((midi % 12) + 12) % 12;
+  const octave = Math.floor(midi / 12) - 1;
+  return `${NOTE_NAMES_FLAT[pitchClass]}${octave}`;
+}
+
+/** Space-separated ascending note names for the currently voiced pitches. */
+export function formatPlayingNotes(pitches: (number | null)[]): string {
+  return pitches
+    .filter((p): p is number => p !== null)
+    .sort((a, b) => a - b)
+    .map(midiToNoteName)
+    .join(' ');
+}
+
+/**
+ * Desktop chord readout: traditional name plus playing notes when available.
+ * e.g. "Bb maj6 - Bb4 D5 F5 G5"
+ */
+export function formatChordReadout(
+  traditionalName: string | null,
+  pitches: (number | null)[]
+): string {
+  if (!traditionalName) return '---';
+
+  const notes = formatPlayingNotes(pitches);
+  if (!notes) return traditionalName;
+
+  return `${traditionalName} - ${notes}`;
+}

--- a/web/src/test/TiltVoicingEngine.test.ts
+++ b/web/src/test/TiltVoicingEngine.test.ts
@@ -14,10 +14,11 @@ import {
   computeTiltVoicing,
   voicingWidthFromTilt,
   tiltVoicingLevelName,
-  tiltInversionLevelName,
+  tiltPositionLevelName,
   TILT_VOICING_LEVEL_NAMES,
-  TILT_INVERSION_LEVEL_NAMES,
-  TILT_INVERSION_DESKTOP_LABELS,
+  TILT_POSITION_MOBILE_LABELS,
+  TILT_POSITION_DESKTOP_LABELS,
+  parallelLevelFromTilt,
   FLAT_TILT,
 } from '../music/TiltVoicingEngine';
 
@@ -89,17 +90,46 @@ describe('mapTiltToPositions', () => {
     });
   });
 
-  it('maps full chest-ward pitch to third inversion', () => {
+  it('maps full chest-ward pitch to high 1st position (one cycle up)', () => {
     expect(mapTiltToPositions({ x: -1, y: -1 })).toEqual({
       inputSteps: 0,
+      parallelSteps: 4,
+    });
+  });
+
+  it('reaches 4th position before full chest-ward tilt', () => {
+    expect(mapTiltToPositions({ x: 0, y: -0.75 })).toEqual({
+      inputSteps: 8,
       parallelSteps: 3,
     });
   });
 
-  it('clamps values outside [-1, 0]', () => {
+  it('maps away-from-chest pitch to lower signed pivot steps', () => {
+    expect(mapTiltToPositions({ x: 0, y: 0.25 })).toEqual({
+      inputSteps: 8,
+      parallelSteps: -1,
+    });
+    expect(mapTiltToPositions({ x: 0, y: 1 })).toEqual({
+      inputSteps: 8,
+      parallelSteps: -4,
+    });
+  });
+
+  it('reaches 2nd position before full away-from-chest tilt', () => {
+    expect(mapTiltToPositions({ x: 0, y: 0.75 })).toEqual({
+      inputSteps: 8,
+      parallelSteps: -3,
+    });
+  });
+
+  it('clamps values outside axis ranges', () => {
     expect(mapTiltToPositions({ x: 0.7, y: -2 })).toEqual({
       inputSteps: 8,
-      parallelSteps: 3,
+      parallelSteps: 4,
+    });
+    expect(mapTiltToPositions({ x: -1, y: 2 })).toEqual({
+      inputSteps: 0,
+      parallelSteps: -4,
     });
   });
 });
@@ -142,7 +172,7 @@ describe('tiltVoicingLevelName', () => {
 });
 
 describe('tiltSampleFromLevels', () => {
-  it('round-trips discrete voicing and inversion levels', () => {
+  it('round-trips discrete voicing and position levels', () => {
     for (let inputSteps = 0; inputSteps <= 8; inputSteps++) {
       for (let parallelSteps = 0; parallelSteps <= 3; parallelSteps++) {
         const sample = tiltSampleFromLevels(inputSteps, parallelSteps);
@@ -155,27 +185,42 @@ describe('tiltSampleFromLevels', () => {
   });
 });
 
-describe('tiltInversionLevelName', () => {
-  it('maps pitch tilt to parallel inversion labels', () => {
-    expect(tiltInversionLevelName({ x: 0, y: 0 })).toBe('Root');
-    expect(tiltInversionLevelName({ x: 0, y: -0.34 })).toBe('First');
-    expect(tiltInversionLevelName({ x: 0, y: -0.67 })).toBe('Second');
-    expect(tiltInversionLevelName({ x: 0, y: -1 })).toBe('Third');
+describe('tiltPositionLevelName', () => {
+  it('maps chest-ward pitch to ascending position labels', () => {
+    expect(tiltPositionLevelName({ x: 0, y: 0 }, 'mobile')).toBe('1st');
+    expect(tiltPositionLevelName({ x: 0, y: -0.25 }, 'mobile')).toBe('2nd');
+    expect(tiltPositionLevelName({ x: 0, y: -0.5 }, 'mobile')).toBe('3rd');
+    expect(tiltPositionLevelName({ x: 0, y: -0.75 }, 'mobile')).toBe('4th');
+    expect(tiltPositionLevelName({ x: 0, y: -1 }, 'mobile')).toBe('1st');
   });
 
-  it('lists four inversion level names', () => {
-    expect(TILT_INVERSION_LEVEL_NAMES).toEqual([
-      'Root',
-      'First',
-      'Second',
-      'Third',
+  it('maps away-from-chest pitch to reversed position labels', () => {
+    expect(tiltPositionLevelName({ x: 0, y: 0.25 }, 'mobile')).toBe('4th');
+    expect(tiltPositionLevelName({ x: 0, y: 0.5 }, 'mobile')).toBe('3rd');
+    expect(tiltPositionLevelName({ x: 0, y: 0.75 }, 'mobile')).toBe('2nd');
+    expect(tiltPositionLevelName({ x: 0, y: 1 }, 'mobile')).toBe('1st');
+  });
+
+  it('lists four position level names', () => {
+    expect(TILT_POSITION_MOBILE_LABELS).toEqual([
+      '1st',
+      '2nd',
+      '3rd',
+      '4th',
     ]);
-    expect(TILT_INVERSION_DESKTOP_LABELS).toEqual([
-      'Root Inv.',
-      'First Inv.',
-      'Second Inv.',
-      'Third Inv.',
+    expect(TILT_POSITION_DESKTOP_LABELS).toEqual([
+      '1st Pos.',
+      '2nd Pos.',
+      '3rd Pos.',
+      '4th Pos.',
     ]);
+  });
+
+  it('uses desktop labels when requested', () => {
+    expect(tiltPositionLevelName({ x: 0, y: -0.75 }, 'desktop')).toBe('4th Pos.');
+    expect(tiltPositionLevelName({ x: 0, y: -1 }, 'desktop')).toBe('1st Pos.');
+    expect(tiltPositionLevelName({ x: 0, y: 0.75 }, 'desktop')).toBe('2nd Pos.');
+    expect(tiltPositionLevelName({ x: 0, y: 1 }, 'desktop')).toBe('1st Pos.');
   });
 });
 
@@ -252,28 +297,34 @@ describe('computeTiltVoicing', () => {
     ).toEqual([60, 64]);
   });
 
-  it('plays the first-inversion bass when parallel level 1 and vertical', () => {
+  it('plays the 2nd-position bass when chest-ward at parallel level 1 and vertical', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.34 }, OCTAVE_RANGE, 0)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.25 }, OCTAVE_RANGE, 0)
     ).toEqual([64]);
   });
 
-  it('plays the second-inversion bass when parallel level 2 and vertical', () => {
+  it('plays the 3rd-position bass when chest-ward at parallel level 2 and vertical', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.67 }, OCTAVE_RANGE, 0)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.5 }, OCTAVE_RANGE, 0)
     ).toEqual([67]);
   });
 
-  it('plays the wide first-inversion voicing when parallel 1 and flat', () => {
+  it('plays high 1st at full chest-ward tilt (one cycle above center)', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: 0, y: -0.34 }, OCTAVE_RANGE, 0)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: -1 }, OCTAVE_RANGE, 0)
+    ).toEqual([72]);
+  });
+
+  it('plays the wide 2nd-position voicing when parallel 1 and flat', () => {
+    expect(
+      computeTiltVoicing(BRANCH, 0, { x: 0, y: -0.25 }, OCTAVE_RANGE, 0)
     ).toEqual(obliqueMotion(1, 9, BRANCH_CYCLE, 60));
   });
 
-  it('plays a three-note stack at parallel 2 with partial roll', () => {
+  it('plays a three-note stack at parallel 3 with partial roll', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -0.75, y: -0.67 }, OCTAVE_RANGE, 0)
-    ).toEqual([64, 67, 69]);
+      computeTiltVoicing(BRANCH, 0, { x: -0.75, y: -0.75 }, OCTAVE_RANGE, 0)
+    ).toEqual([67, 69, 72]);
   });
 
   it('voices a minor sixth cycle (Trunk) correctly when flat', () => {
@@ -320,6 +371,34 @@ describe('computeTiltVoicing', () => {
         69
       )
     ).toEqual([69]);
+  });
+
+  it('lowers the unison pivot when tilted away from chest', () => {
+    const flatUnison = computeTiltVoicing(
+      BRANCH,
+      0,
+      { x: -1, y: 0 },
+      OCTAVE_RANGE,
+      0
+    );
+    const downTiltUnison = computeTiltVoicing(
+      BRANCH,
+      0,
+      { x: -1, y: 0.25 },
+      OCTAVE_RANGE,
+      0
+    );
+    expect(flatUnison).toEqual([60]);
+    expect(downTiltUnison).toEqual([57]);
+    expect(downTiltUnison[0]).toBeLessThan(flatUnison[0]!);
+    expect(parallelLevelFromTilt({ x: -1, y: 0.25 })).toBe(-1);
+    expect(tiltPositionLevelName({ x: -1, y: 0.25 }, 'mobile')).toBe('4th');
+  });
+
+  it('plays low 1st at full away-from-chest tilt (one cycle below center)', () => {
+    expect(
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: 1 }, OCTAVE_RANGE, 0)
+    ).toEqual([48]);
   });
 
   it('returns empty when all voices are off', () => {

--- a/web/src/test/TiltVoicingEngine.test.ts
+++ b/web/src/test/TiltVoicingEngine.test.ts
@@ -196,8 +196,10 @@ describe('obliqueMotion', () => {
     expect(obliqueMotion(0, 4, BRANCH_CYCLE, 60)).toEqual([57, 60, 64, 67]);
   });
 
-  it('thins the octave chord (width 5) by dropping the middle note', () => {
-    expect(obliqueMotion(0, 5, BRANCH_CYCLE, 60)).toEqual([55, 57, 64, 67]);
+  it('plays all five notes at width 5 (Octave) without thinning', () => {
+    expect(obliqueMotion(0, 5, BRANCH_CYCLE, 60)).toEqual([
+      55, 57, 60, 64, 67,
+    ]);
   });
 
   it('thins width 6 with the drop 2 rule', () => {
@@ -233,50 +235,50 @@ describe('obliqueMotion', () => {
 
 describe('computeTiltVoicing', () => {
   it('plays the widest voicing when flat (reversed from Python)', () => {
-    expect(computeTiltVoicing(BRANCH, 0, FLAT_TILT, OCTAVE_RANGE)).toEqual([
+    expect(computeTiltVoicing(BRANCH, 0, FLAT_TILT, OCTAVE_RANGE, 0)).toEqual([
       48, 57, 64, 67, 72,
     ]);
   });
 
   it('narrows to the single pivot note when fully vertical', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -1, y: 0 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: 0 }, OCTAVE_RANGE, 0)
     ).toEqual([60]);
   });
 
   it('plays Third (note above pivot) at the second roll stop', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -0.875, y: 0 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: -0.875, y: 0 }, OCTAVE_RANGE, 0)
     ).toEqual([60, 64]);
   });
 
   it('plays the first-inversion bass when parallel level 1 and vertical', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.34 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.34 }, OCTAVE_RANGE, 0)
     ).toEqual([64]);
   });
 
   it('plays the second-inversion bass when parallel level 2 and vertical', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.67 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: -1, y: -0.67 }, OCTAVE_RANGE, 0)
     ).toEqual([67]);
   });
 
   it('plays the wide first-inversion voicing when parallel 1 and flat', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: 0, y: -0.34 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: 0, y: -0.34 }, OCTAVE_RANGE, 0)
     ).toEqual(obliqueMotion(1, 9, BRANCH_CYCLE, 60));
   });
 
   it('plays a three-note stack at parallel 2 with partial roll', () => {
     expect(
-      computeTiltVoicing(BRANCH, 0, { x: -0.75, y: -0.67 }, OCTAVE_RANGE)
+      computeTiltVoicing(BRANCH, 0, { x: -0.75, y: -0.67 }, OCTAVE_RANGE, 0)
     ).toEqual([64, 67, 69]);
   });
 
   it('voices a minor sixth cycle (Trunk) correctly when flat', () => {
     const trunk = [0, 3, 7, 9]; // C Eb G A
-    expect(computeTiltVoicing(trunk, 0, FLAT_TILT, OCTAVE_RANGE)).toEqual([
+    expect(computeTiltVoicing(trunk, 0, FLAT_TILT, OCTAVE_RANGE, 0)).toEqual([
       48, 57, 63, 67, 72,
     ]);
   });
@@ -285,24 +287,44 @@ describe('computeTiltVoicing', () => {
     // Branch with the second voice borrowed up into Fire: C F G A.
     const borrowed = [0, 5, 7, 9];
     expect(
-      computeTiltVoicing(borrowed, 0, { x: -0.5, y: 0 }, OCTAVE_RANGE)
-    ).toEqual([55, 57, 65, 67]);
+      computeTiltVoicing(borrowed, 0, { x: -0.5, y: 0 }, OCTAVE_RANGE, 0)
+    ).toEqual([55, 57, 60, 65, 67]);
   });
 
   it('follows the octave range setting', () => {
-    expect(computeTiltVoicing(BRANCH, 0, { x: -1, y: 0 }, 1)).toEqual([36]);
+    expect(computeTiltVoicing(BRANCH, 0, { x: -1, y: 0 }, 1, 0)).toEqual([36]);
   });
 
   it('handles a non-zero root pitch class', () => {
     // Branch at tonal center Bb: root pc 10, home = 10 + 60 = 70.
     expect(
-      computeTiltVoicing([10, 14, 17, 19], 10, { x: -1, y: 0 }, OCTAVE_RANGE)
+      computeTiltVoicing(
+        [10, 14, 17, 19],
+        10,
+        { x: -1, y: 0 },
+        OCTAVE_RANGE,
+        10
+      )
     ).toEqual([70]);
+  });
+
+  it('keeps Fire contrary to Branch when tonal center is Bb', () => {
+    // Fire default root A (9), pivot one semitone below Branch (70) -> 69.
+    expect(
+      computeTiltVoicing(
+        [0, 3, 6, 9],
+        9,
+        { x: -1, y: 0 },
+        OCTAVE_RANGE,
+        10,
+        69
+      )
+    ).toEqual([69]);
   });
 
   it('returns empty when all voices are off', () => {
     expect(
-      computeTiltVoicing([null, null, null, null], 0, FLAT_TILT, OCTAVE_RANGE)
+      computeTiltVoicing([null, null, null, null], 0, FLAT_TILT, OCTAVE_RANGE, 0)
     ).toEqual([]);
   });
 });

--- a/web/src/test/borrowingMuteIntegration.test.ts
+++ b/web/src/test/borrowingMuteIntegration.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  BorrowingLogic,
+  getInitialBorrowingState,
+  type BorrowingState,
+} from '../music/BorrowingLogic';
+import type { Chord } from '../music/ChordManager';
+import {
+  computeTiltVoicing,
+  tiltSampleFromLevels,
+  DEFAULT_STATIC_VOICING_LEVEL,
+  type TiltSample,
+} from '../music/TiltVoicingEngine';
+import { chordManager } from '../music/ChordManager';
+
+const logic = new BorrowingLogic();
+const OCTAVE_RANGE = 3;
+const BB_TONAL_CENTER = 10;
+
+/** Close voicing at 2nd Position (parallelSteps=1, inputSteps=3 → width 4). */
+const SECOND_POSITION_CLOSE = tiltSampleFromLevels(3, 1);
+
+/** Default drone voicing at 2nd Position. */
+const DRONE_SECOND_POSITION = tiltSampleFromLevels(
+  DEFAULT_STATIC_VOICING_LEVEL,
+  1
+);
+
+const DOUBLE_OCTAVE = tiltSampleFromLevels(DEFAULT_STATIC_VOICING_LEVEL, 0);
+
+function pitchClasses(midiNotes: number[]): number[] {
+  return [...new Set(midiNotes.map((n) => ((n % 12) + 12) % 12))].sort(
+    (a, b) => a - b
+  );
+}
+
+function muteLine(line: 1 | 2 | 3 | 4) {
+  const state = getInitialBorrowingState();
+  state.noteStates[line] = 'off';
+  return state;
+}
+
+/** Mirrors useChordPlayback.computeVoicedPitches mute behavior. */
+function computeVoicedWithMutes(
+  chord: Chord,
+  state: BorrowingState,
+  tilt: TiltSample,
+  octaveRange: number,
+  tonalCenter: number
+): number[] {
+  const structure = logic.generatePitchStructureForVoicing(chord, state);
+  const rootPitchClass = chord.pitches[chord.rootPositionIndex] % 12;
+  const voiced = computeTiltVoicing(
+    structure,
+    rootPitchClass,
+    tilt,
+    octaveRange,
+    tonalCenter
+  );
+  return logic.filterVoicingMutes(
+    voiced,
+    logic.getMutedPitchClasses(chord, state)
+  );
+}
+
+describe('borrowing mute integration', () => {
+  beforeEach(() => {
+    chordManager.setTonalCenterOffset(0);
+    chordManager.setOctaveRange(OCTAVE_RANGE);
+  });
+
+  it('Branch at C: muting Root removes C at 2nd Position', () => {
+    const branch = chordManager.getChordByName('Branch')!;
+    expect(branch.pitches).toEqual([0, 4, 7, 9]);
+
+    const voiced = computeVoicedWithMutes(
+      branch,
+      muteLine(1),
+      SECOND_POSITION_CLOSE,
+      OCTAVE_RANGE,
+      0
+    );
+    expect(pitchClasses(voiced)).not.toContain(0);
+    expect(pitchClasses(voiced)).toContain(4);
+  });
+
+  it('Branch at C: muting 3rd removes E at 2nd Position', () => {
+    const branch = chordManager.getChordByName('Branch')!;
+    const voiced = computeVoicedWithMutes(
+      branch,
+      muteLine(2),
+      SECOND_POSITION_CLOSE,
+      OCTAVE_RANGE,
+      0
+    );
+    expect(pitchClasses(voiced)).not.toContain(4);
+    expect(pitchClasses(voiced)).toContain(0);
+  });
+
+  it('Branch at Bb: muting Root filters Bb from double octave without re-spreading', () => {
+    chordManager.setTonalCenterOffset(BB_TONAL_CENTER);
+    const branch = chordManager.getChordByName('Branch')!;
+
+    const full = computeVoicedWithMutes(
+      branch,
+      getInitialBorrowingState(),
+      DOUBLE_OCTAVE,
+      OCTAVE_RANGE,
+      BB_TONAL_CENTER
+    );
+    const muted = computeVoicedWithMutes(
+      branch,
+      muteLine(1),
+      DOUBLE_OCTAVE,
+      OCTAVE_RANGE,
+      BB_TONAL_CENTER
+    );
+
+    expect(full).toEqual([58, 67, 74, 77, 82]);
+    expect(muted).toEqual([67, 74, 77]);
+    expect(muted).toEqual(full.filter((n) => n % 12 !== BB_TONAL_CENTER));
+  });
+
+  it('Branch at C: muting Root removes all C pitch classes in Double Octave', () => {
+    const branch = chordManager.getChordByName('Branch')!;
+    const full = computeVoicedWithMutes(
+      branch,
+      getInitialBorrowingState(),
+      DOUBLE_OCTAVE,
+      OCTAVE_RANGE,
+      0
+    );
+    const muted = computeVoicedWithMutes(
+      branch,
+      muteLine(1),
+      DOUBLE_OCTAVE,
+      OCTAVE_RANGE,
+      0
+    );
+
+    expect(muted.every((n) => n % 12 !== 0)).toBe(true);
+    expect(muted).toEqual(full.filter((n) => n % 12 !== 0));
+  });
+
+  it('Branch at C: drone replay path respects mute at 2nd Position', () => {
+    const branch = chordManager.getChordByName('Branch')!;
+    const voiced = computeVoicedWithMutes(
+      branch,
+      muteLine(1),
+      DRONE_SECOND_POSITION,
+      OCTAVE_RANGE,
+      0
+    );
+    expect(pitchClasses(voiced)).not.toContain(0);
+    expect(pitchClasses(voiced)).toContain(4);
+  });
+
+  it('muting Root is subtractive at every position level', () => {
+    const branch = chordManager.getChordByName('Branch')!;
+    const muteRoot = muteLine(1);
+
+    for (let position = 0; position <= 3; position += 1) {
+      const tilt = tiltSampleFromLevels(DEFAULT_STATIC_VOICING_LEVEL, position);
+      const full = computeVoicedWithMutes(
+        branch,
+        getInitialBorrowingState(),
+        tilt,
+        OCTAVE_RANGE,
+        0
+      );
+      const muted = computeVoicedWithMutes(
+        branch,
+        muteRoot,
+        tilt,
+        OCTAVE_RANGE,
+        0
+      );
+
+      expect(muted).toEqual(full.filter((n) => n % 12 !== 0));
+      expect(muted.every((n) => n % 12 !== 0)).toBe(true);
+      expect(muted.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/test/elementChemistry.test.ts
+++ b/web/src/test/elementChemistry.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { computeElementFormula } from '../music/elementChemistry';
+
+describe('computeElementFormula', () => {
+  it('counts each pitch class once for Branch at Bb', () => {
+    expect(computeElementFormula([58, 62, 65, 69], 10)).toEqual({
+      earth: 1,
+      wind: 2,
+      fire: 1,
+    });
+  });
+
+  it('does not double-count repeated pitch classes in wide voicings', () => {
+    // Bb3, Bb4, D4, F4, A4: only one Earth from Bb.
+    expect(computeElementFormula([58, 70, 62, 65, 69], 10)).toEqual({
+      earth: 1,
+      wind: 2,
+      fire: 1,
+    });
+  });
+
+  it('returns null when no pitches are active', () => {
+    expect(computeElementFormula([null, null, null, null], 10)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Anchor elemental diminished chords with contrary-motion roots so playback stays in a continuous register at any tonal center.
- Rename inversion to Position and extend the pitch ladder so full tilt reaches 1st again at both ends (±4 steps).
- Fix voice borrowing mute to subtract muted pitch classes from the current tilt voicing at any width and position, instead of rebuilding from a reduced tone cycle.
- Add regression tests for elemental roots, position/tilt voicing, and borrowing mute integration (including Bb maj6 double octave).

## Test plan
- [x] Select Earth/Wind/Fire at several tonal centers; confirm diminished roots follow contrary motion from the opposite child chord.
- [x] On phone tilt mode, verify Position labels (1st–4th) and full pitch tilt at both extremes land on 1st again.
- [x] Branch at Bb, Double Octave: full voicing is Bb3 G4 D5 F5 Bb5; mute Root yields G4 D5 F5 only.
- [x] Branch at C, 2nd Position: mute Root removes C; mute 3rd removes E; bass/register of remaining notes stays unchanged.
- [x] Run `npm test` in `web/`.